### PR TITLE
Refactor entities to interfaces

### DIFF
--- a/MLOps.NET.Azure/Entities/Experiment.cs
+++ b/MLOps.NET.Azure/Entities/Experiment.cs
@@ -17,7 +17,5 @@ namespace MLOps.NET.Azure.Entities
         public Guid Id { get; set; }
 
         public string ExperimentName { get; set; }
-
-        public IList<IRun> Runs { get; set; }
     }
 }

--- a/MLOps.NET.Azure/Entities/Experiment.cs
+++ b/MLOps.NET.Azure/Entities/Experiment.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Azure.Cosmos.Table;
+using MLOps.NET.Entities.Entities;
 using System;
 using System.Collections.Generic;
 
 namespace MLOps.NET.Azure.Entities
 {
-    internal sealed class Experiment : TableEntity
+    internal sealed class Experiment : TableEntity, IExperiment
     {
         public Experiment(string experimentName)
         {
@@ -17,6 +18,6 @@ namespace MLOps.NET.Azure.Entities
 
         public string ExperimentName { get; set; }
 
-        public List<Run> Runs { get; set; }
+        public IList<IRun> Runs { get; set; }
     }
 }

--- a/MLOps.NET.Azure/Entities/Metric.cs
+++ b/MLOps.NET.Azure/Entities/Metric.cs
@@ -11,9 +11,13 @@ namespace MLOps.NET.Azure.Entities
             PartitionKey = runId.ToString();
             RowKey = MetricName = metricName;
             Value = value;
+            RunId = runId;
         }
 
         public string MetricName { get; set; }
+
         public double Value { get; set; }
+
+        public Guid RunId { get; set; }
     }
 }

--- a/MLOps.NET.Azure/Entities/Metric.cs
+++ b/MLOps.NET.Azure/Entities/Metric.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.Azure.Cosmos.Table;
+using MLOps.NET.Entities.Entities;
 using System;
 
 namespace MLOps.NET.Azure.Entities
 {
-    internal sealed class Metric : TableEntity
+    internal sealed class Metric : TableEntity, IMetric
     {
         public Metric(Guid runId, string metricName, double value)
         {

--- a/MLOps.NET.Azure/Entities/Run.cs
+++ b/MLOps.NET.Azure/Entities/Run.cs
@@ -15,6 +15,7 @@ namespace MLOps.NET.Azure.Entities
             PartitionKey = experimentId.ToString();
             RowKey = Id.ToString();
             RunDate = DateTime.Now;
+            ExperimentId = experimentId;
         }
 
         public Guid Id { get; set; }

--- a/MLOps.NET.Azure/Entities/Run.cs
+++ b/MLOps.NET.Azure/Entities/Run.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.Azure.Cosmos.Table;
+using MLOps.NET.Entities.Entities;
 using System;
-using System.Collections.Generic;
 
 namespace MLOps.NET.Azure.Entities
 {
-    internal sealed class Run : TableEntity
+    internal sealed class Run : TableEntity, IRun
     {
         public Run() { }
- 
+
         public Run(Guid experimentId)
         {
             Id = Guid.NewGuid();

--- a/MLOps.NET.Azure/Entities/Run.cs
+++ b/MLOps.NET.Azure/Entities/Run.cs
@@ -20,5 +20,7 @@ namespace MLOps.NET.Azure.Entities
         public Guid Id { get; set; }
 
         public DateTime RunDate { get; set; }
+
+        public Guid ExperimentId { get; set; }
     }
 }

--- a/MLOps.NET/Entities/Interfaces/IExperiment.cs
+++ b/MLOps.NET/Entities/Interfaces/IExperiment.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MLOps.NET.Entities.Entities
+{
+    public interface IExperiment
+    {
+        string ExperimentName { get; set; }
+        Guid Id { get; set; }
+        IList<IRun> Runs { get; set; }
+    }
+}

--- a/MLOps.NET/Entities/Interfaces/IExperiment.cs
+++ b/MLOps.NET/Entities/Interfaces/IExperiment.cs
@@ -7,6 +7,5 @@ namespace MLOps.NET.Entities.Entities
     {
         string ExperimentName { get; set; }
         Guid Id { get; set; }
-        IList<IRun> Runs { get; set; }
     }
 }

--- a/MLOps.NET/Entities/Interfaces/IMetric.cs
+++ b/MLOps.NET/Entities/Interfaces/IMetric.cs
@@ -1,0 +1,8 @@
+﻿namespace MLOps.NET.Entities.Entities
+{
+    public interface IMetric
+    {
+        string MetricName { get; set; }
+        double Value { get; set; }
+    }
+}

--- a/MLOps.NET/Entities/Interfaces/IMetric.cs
+++ b/MLOps.NET/Entities/Interfaces/IMetric.cs
@@ -1,8 +1,11 @@
-﻿namespace MLOps.NET.Entities.Entities
+﻿using System;
+
+namespace MLOps.NET.Entities.Entities
 {
     public interface IMetric
     {
         string MetricName { get; set; }
         double Value { get; set; }
+        Guid RunId { get; set; }
     }
 }

--- a/MLOps.NET/Entities/Interfaces/IRun.cs
+++ b/MLOps.NET/Entities/Interfaces/IRun.cs
@@ -6,5 +6,6 @@ namespace MLOps.NET.Entities.Entities
     {
         Guid Id { get; set; }
         DateTime RunDate { get; set; }
+        Guid ExperimentId { get; set; }
     }
 }

--- a/MLOps.NET/Entities/Interfaces/IRun.cs
+++ b/MLOps.NET/Entities/Interfaces/IRun.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace MLOps.NET.Entities.Entities
+{
+    public interface IRun
+    {
+        Guid Id { get; set; }
+        DateTime RunDate { get; set; }
+    }
+}


### PR DESCRIPTION
We need to extract the interfaces from entities in order to prepare the code for adding another storage (SQLite).