### PR TITLE
added function to upload the model artifact to azure blob storage

### DIFF
--- a/MLOps.NET.Azure/MLLifeCycleManagerExtensions.cs
+++ b/MLOps.NET.Azure/MLLifeCycleManagerExtensions.cs
@@ -7,6 +7,7 @@ namespace MLOps.NET.Azure
         public static MLLifeCycleManager UseAzureStorage(this MLLifeCycleManager mLLifeCycleManager, string connectionString)
         {
             mLLifeCycleManager.MetaDataStore = new StorageAccountMetaDataStore(connectionString);
+            mLLifeCycleManager.ModelRepository = new StorageAccountModelRepository(connectionString);
 
             return mLLifeCycleManager;
         }

--- a/MLOps.NET.Azure/MLOps.NET.Azure.csproj
+++ b/MLOps.NET.Azure/MLOps.NET.Azure.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.4.3" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
   </ItemGroup>
 

--- a/MLOps.NET.Azure/Storage/StorageAccountModelRepository.cs
+++ b/MLOps.NET.Azure/Storage/StorageAccountModelRepository.cs
@@ -9,18 +9,18 @@ namespace MLOps.NET.Storage
     internal sealed class StorageAccountModelRepository : IModelRepository
     {
         private readonly BlobContainerClient blobContainerClient;
-        private const string _containerName = "model-repository";
-        private const string _fileExtension = ".zip";
+        private const string containerName = "model-repository";
+        private const string fileExtension = ".zip";
 
         public StorageAccountModelRepository(string connectionString)
         {
-            this.blobContainerClient = new BlobContainerClient(connectionString, _containerName);
+            this.blobContainerClient = new BlobContainerClient(connectionString, containerName);
         }
 
         public async Task UploadModelAsync(Guid runId, string filePath)
         {
             await this.blobContainerClient.CreateIfNotExistsAsync();
-            BlobClient blobClient = this.blobContainerClient.GetBlobClient(runId.ToString() + _fileExtension);
+            BlobClient blobClient = this.blobContainerClient.GetBlobClient(runId.ToString() + fileExtension);
             using (var fileStream = File.OpenRead(filePath))
             {
                 await blobClient.UploadAsync(fileStream, true);

--- a/MLOps.NET.Azure/Storage/StorageAccountModelRepository.cs
+++ b/MLOps.NET.Azure/Storage/StorageAccountModelRepository.cs
@@ -1,0 +1,30 @@
+﻿using Azure.Storage.Blobs;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Storage
+{
+    internal sealed class StorageAccountModelRepository : IModelRepository
+    {
+        private readonly BlobContainerClient blobContainerClient;
+        private const string _containerName = "model-repository";
+        private const string _fileExtension = ".zip";
+
+        public StorageAccountModelRepository(string connectionString)
+        {
+            this.blobContainerClient = new BlobContainerClient(connectionString, _containerName);
+        }
+
+        public async Task UploadModelAsync(Guid runId, string filePath)
+        {
+            await this.blobContainerClient.CreateIfNotExistsAsync();
+            BlobClient blobClient = this.blobContainerClient.GetBlobClient(runId.ToString() + _fileExtension);
+            using (var fileStream = File.OpenRead(filePath))
+            {
+                await blobClient.UploadAsync(fileStream, true);
+            }
+        }
+    }
+}

--- a/MLOps.NET/MLLifeCycleManager.cs
+++ b/MLOps.NET/MLLifeCycleManager.cs
@@ -8,6 +8,8 @@ namespace MLOps.NET
     {
         public IMetaDataStore MetaDataStore { get; set; }
 
+        public IModelRepository ModelRepository { get; set; }
+
         public async Task<Guid> CreateExperimentAsync(string name)
         {
             EnsureStorageProviderConfigured();
@@ -29,9 +31,21 @@ namespace MLOps.NET
             await MetaDataStore.LogMetricAsync(runId, metricName, metricValue);
         }
 
+        /// <summary>
+        /// Uploads the model zip file to azure blob storage model-repository container.
+        /// </summary>
+        /// <param name="runId"></param>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public async Task UploadModelAsync(Guid runId, string filePath)
+        {
+            EnsureStorageProviderConfigured();
+            await ModelRepository.UploadModelAsync(runId, filePath);
+        }
+
         private void EnsureStorageProviderConfigured()
         {
-            if (MetaDataStore == null)
+            if (MetaDataStore == null || ModelRepository == null)
             {
                 throw new InvalidOperationException("The storage provider has not been properly set up. Please call Rutix, Daniel and usertyuu should you have any questions");
             }

--- a/MLOps.NET/MLLifeCycleManager.cs
+++ b/MLOps.NET/MLLifeCycleManager.cs
@@ -32,10 +32,10 @@ namespace MLOps.NET
         }
 
         /// <summary>
-        /// Uploads the model zip file to azure blob storage model-repository container.
+        /// Uploads the model zip artifact to the desired storage location.
         /// </summary>
         /// <param name="runId"></param>
-        /// <param name="filePath"></param>
+        /// <param name="filePath">local file path where the model file is saved</param>
         /// <returns></returns>
         public async Task UploadModelAsync(Guid runId, string filePath)
         {

--- a/MLOps.NET/Storage/Interfaces/IModelRepository.cs
+++ b/MLOps.NET/Storage/Interfaces/IModelRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Storage
+{
+    public interface IModelRepository
+    {
+        Task UploadModelAsync(Guid runId, string filePath);
+    }
+}


### PR DESCRIPTION
Fixes #3 

Contains the changes to upload the model artifact to a container in azure blob storage.

1. Container name is 'model-repository'. If it doesn't the method creates it first.
2. The blob name is the runId with a .zip extenion.
3. Doesn't apply any permissions on the blob.
