### PR TITLE
Fix duplicate experiment creation

### DIFF
--- a/src/MLOps.NET.Azure/Entities/Experiment.cs
+++ b/src/MLOps.NET.Azure/Entities/Experiment.cs
@@ -14,6 +14,12 @@ namespace MLOps.NET.Azure.Entities
             RowKey = experimentName;
         }
 
+        public Experiment()
+        {
+
+        }
+
+
         public Guid Id { get; set; }
 
         public string ExperimentName { get; set; }

--- a/src/MLOps.NET.Azure/Entities/Experiment.cs
+++ b/src/MLOps.NET.Azure/Entities/Experiment.cs
@@ -11,7 +11,7 @@ namespace MLOps.NET.Azure.Entities
         {
             Id = Guid.NewGuid();
             PartitionKey = experimentName;
-            RowKey = Id.ToString();
+            RowKey = experimentName;
         }
 
         public Guid Id { get; set; }

--- a/src/MLOps.NET.Azure/Entities/Experiment.cs
+++ b/src/MLOps.NET.Azure/Entities/Experiment.cs
@@ -7,18 +7,15 @@ namespace MLOps.NET.Azure.Entities
 {
     internal sealed class Experiment : TableEntity, IExperiment
     {
+
+        public Experiment() { }
+
         public Experiment(string experimentName)
         {
             Id = Guid.NewGuid();
             PartitionKey = experimentName;
             RowKey = experimentName;
         }
-
-        public Experiment()
-        {
-
-        }
-
 
         public Guid Id { get; set; }
 

--- a/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
+++ b/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
@@ -18,7 +18,7 @@ namespace MLOps.NET.Storage
         public async Task<Guid> CreateExperimentAsync(string name)
         {
             // Check if experiment exists
-            var existingExperiment = await RetrieveEntityAsync<Experiment>(name, name, "Experiment");
+            var existingExperiment = await RetrieveEntityAsync<Experiment>(name, name, nameof(Experiment));
 
             // Add if it doesn't exist
             if(existingExperiment == null)

--- a/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
+++ b/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
@@ -24,7 +24,7 @@ namespace MLOps.NET.Storage
             if(existingExperiment == null)
             {
                 var experiment = new Experiment(name);
-                var addedExperiment = await InsertOrMerge(experiment, nameof(Experiment));
+                var addedExperiment = await InsertOrMergeAsync(experiment, nameof(Experiment));
                 return addedExperiment.Id;
             }
             

--- a/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
+++ b/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.Cosmos.Table;
+using Microsoft.Azure.Documents.SystemFunctions;
 using MLOps.NET.Azure.Entities;
 using System;
 using System.Threading.Tasks;
@@ -16,10 +17,19 @@ namespace MLOps.NET.Storage
 
         public async Task<Guid> CreateExperimentAsync(string name)
         {
-            var experiment = new Experiment(name);
-            var addedExperiment = await InsertOrMerge(experiment, nameof(Experiment));
+            // Check if experiment exists
+            var existingExperiment = await RetrieveEntityAsync<Experiment>(name, name, "Experiment");
 
-            return addedExperiment.Id;
+            // Add if it doesn't exist
+            if(existingExperiment == null)
+            {
+                var experiment = new Experiment(name);
+                var addedExperiment = await InsertOrMerge(experiment, nameof(Experiment));
+                return addedExperiment.Id;
+            }
+            
+            // Return existing id if exists
+            return existingExperiment.Id;
         }
 
         public async Task<Guid> CreateRunAsync(Guid experimentId)
@@ -65,6 +75,18 @@ namespace MLOps.NET.Storage
             CloudTable table = tableClient.GetTableReference(tableName);
 
             var retrieveOperation = TableOperation.Retrieve<TEntity>(partitionKey.ToString(), rowKey.ToString());
+            var result = await table.ExecuteAsync(retrieveOperation);
+
+            return result.Result as TEntity;
+        }
+
+        private async Task<TEntity> RetrieveEntityAsync<TEntity>(string partitionKey, string rowKey, string tableName) where TEntity : TableEntity
+        {
+            var tableClient = storageAccount.CreateCloudTableClient(new TableClientConfiguration());
+
+            CloudTable table = tableClient.GetTableReference(tableName);
+
+            var retrieveOperation = TableOperation.Retrieve<TEntity>(partitionKey, rowKey);
             var result = await table.ExecuteAsync(retrieveOperation);
 
             return result.Result as TEntity;


### PR DESCRIPTION
## Resolves

Fix #48 

## Description

Before using a GUID as the RowKey would treat each experiment as unique. Using the experimentName as the RowKey fixes that. 


The following code creates the experiments seen in the screenshot:

```csharp
await store.CreateExperimentAsync("MLExp");
await store.CreateExperimentAsync("MLExp");
await store.CreateExperimentAsync("Test1");
await store.CreateExperimentAsync("Test2");
await store.CreateExperimentAsync("MLEXP");
await store.CreateExperimentAsync("Test2");
await store.CreateExperimentAsync("MLExp");
await store.CreateExperimentAsync("TEST1");
await store.CreateExperimentAsync("Test1");
await store.CreateExperimentAsync("Test2");
```

![image](https://user-images.githubusercontent.com/11130940/83955941-6d0ccb00-a826-11ea-95df-1f06411045ab.png)

Additionally, if the experiment exists the ID not generated every time. The following code generates the following output.

```csharp
foreach(var i in Enumerable.Range(0,3))
{
    var exp = await store.CreateExperimentAsync("MLExp");
    Console.WriteLine($"Guid {i} {exp.ToString()}");
}
```

```text
Guid 0 aecac696-8bf7-4ae2-b123-d3ecf048a87a
Guid 1 aecac696-8bf7-4ae2-b123-d3ecf048a87a
Guid 2 aecac696-8bf7-4ae2-b123-d3ecf048a87a
```

