### PR TITLE
Enforcing compiler warnings as errors

### DIFF
--- a/src/MLOps.NET.Azure/MLOps.NET.Azure.csproj
+++ b/src/MLOps.NET.Azure/MLOps.NET.Azure.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>MLOps.NET Azure table storage provider</Description>
     <PackageTags>$(PackageTags), azure</PackageTags>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/MLOps.NET.SQLite.IntegrationTests/MLOps.NET.SQLite.IntegrationTests.csproj
+++ b/src/MLOps.NET.SQLite.IntegrationTests/MLOps.NET.SQLite.IntegrationTests.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--Do not enforce missing XML warnings on test project -->
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MLOps.NET.SQLite/MLOps.NET.SQLite.csproj
+++ b/src/MLOps.NET.SQLite/MLOps.NET.SQLite.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>MLOps.NET SQLite storage provider</Description>
     <PackageTags>$(PackageTags), sqlite</PackageTags>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MLOps.NET.SQLite/Storage/LocalFileModelRepository.cs
+++ b/src/MLOps.NET.SQLite/Storage/LocalFileModelRepository.cs
@@ -18,7 +18,6 @@ namespace MLOps.NET.Storage
         /// </summary>
         /// <param name="runId"></param>
         /// <param name="sourceFilePath"></param>
-        /// <param name="destinationFolder"></param>
         /// <returns></returns>
         public async Task UploadModelAsync(Guid runId, string sourceFilePath)
         {

--- a/src/MLOps.NET/MLOps.NET.csproj
+++ b/src/MLOps.NET/MLOps.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
## Resolves
Fixes #72 

## Description
Enforcing compiler warnings as errors (because we can)
