### PR TITLE
create local folder if not exists and make destination folder optional.

### DIFF
--- a/src/MLOps.NET.SQLite/MLOpsBuilderExtensions.cs
+++ b/src/MLOps.NET.SQLite/MLOpsBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace MLOps.NET.SQLite
         /// <param name="builder">MLOpsBuilder to add Azure Storage providers to</param>
         /// <param name="destinationFolder">Destination folder (optional with default value of C:\MLops)</param>
         /// <returns>Provided MLOpsBuilder for chaining</returns>
-        public static MLOpsBuilder UseSQLite(this MLOpsBuilder builder, string destinationFolder)
+        public static MLOpsBuilder UseSQLite(this MLOpsBuilder builder, string destinationFolder = @"C:\MLops")
         {
             builder.UseMetaDataStore(new SQLiteMetaDataStore());
             builder.UseModelRepository(new LocalFileModelRepository(destinationFolder));

--- a/src/MLOps.NET.SQLite/Storage/LocalFileModelRepository.cs
+++ b/src/MLOps.NET.SQLite/Storage/LocalFileModelRepository.cs
@@ -23,6 +23,9 @@ namespace MLOps.NET.Storage
         {
             using (var fileStream = File.OpenRead(sourceFilePath))
             {
+                if (!Directory.Exists(destinationFolder))
+                    Directory.CreateDirectory(destinationFolder);
+
                 string destFile = Path.Combine(destinationFolder, $"{runId}.zip");
                 await Task.Run(() => { File.Copy(sourceFilePath, destFile, true); });
             }


### PR DESCRIPTION
## Resolves
Fixes #95 
Fixes #93

## Description
Creates a destination folder if not exists for MlOps.Net.SqlLite and made the destination folder optional when creating an instance of mlopscontext with sqllite.
