### PR TITLE
Add ability to link a  Run with a git commit hash

### DIFF
--- a/src/MLOps.NET.Azure/Entities/Run.cs
+++ b/src/MLOps.NET.Azure/Entities/Run.cs
@@ -28,5 +28,7 @@ namespace MLOps.NET.Azure.Entities
         public List<IMetric> Metrics { get; set; }
 
         public TimeSpan TrainingTime { get; set; }
+
+        public string GitCommitHash { get; set; }
     }
 }

--- a/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
+++ b/src/MLOps.NET.Azure/Storage/StorageAccountMetaDataStore.cs
@@ -34,9 +34,13 @@ namespace MLOps.NET.Storage
             return existingExperiment.Id;
         }
 
-        public async Task<Guid> CreateRunAsync(Guid experimentId)
+        public async Task<Guid> CreateRunAsync(Guid experimentId, string gitCommitHash = "")
         {
-            var run = new Run(experimentId);
+            var run = new Run(experimentId)
+            {
+                GitCommitHash = gitCommitHash
+            };
+
             var addedRun = await InsertOrMergeAsync(run, nameof(Run));
 
             return addedRun.Id;

--- a/src/MLOps.NET.SQLite/Entities/Run.cs
+++ b/src/MLOps.NET.SQLite/Entities/Run.cs
@@ -26,5 +26,7 @@ namespace MLOps.NET.SQLite.Entities
         public List<IMetric> Metrics { get; set; }
 
         public TimeSpan TrainingTime { get; set; }
+
+        public string GitCommitHash { get; set; }
     }
 }

--- a/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
+++ b/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
@@ -22,11 +22,15 @@ namespace MLOps.NET.Storage
             }
         }
 
-        public async Task<Guid> CreateRunAsync(Guid experimentId)
+        public async Task<Guid> CreateRunAsync(Guid experimentId, string gitCommitHash = "")
         {
             using (var db = new LocalDbContext())
             {
-                var run = new Run(experimentId);
+                var run = new Run(experimentId)
+                {
+                    GitCommitHash = gitCommitHash
+                };
+
                 await db.Runs.AddAsync(run);
                 await db.SaveChangesAsync();
                 

--- a/src/MLOps.NET.Tests/LifeCycleCatalogTests.cs
+++ b/src/MLOps.NET.Tests/LifeCycleCatalogTests.cs
@@ -63,5 +63,29 @@ namespace MLOps.NET.Tests
             //Assert
             metaDataStoreMock.Verify(x => x.SetTrainingTimeAsync(runId, trainingTime), Times.Once());
         }
+
+        [TestMethod]
+        public async Task CreateRunAsync_WithGitCommitHash_SetsGitCommitHash()
+        {
+            //Arrange
+            var gitCommitHash = "12323239329392";
+
+            //Act
+            var runId = await sut.CreateRunAsync(Guid.NewGuid(), gitCommitHash);
+
+            //Assert
+            this.metaDataStoreMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), gitCommitHash), Times.Once());
+        }
+
+        [TestMethod]
+        public async Task CreateRunAsync_WithoutGitCommitHash_ShouldProvideEmptyGitCommitHash()
+        {
+            //Arrange
+            //Act
+            var runId = await sut.CreateRunAsync(Guid.NewGuid());
+
+            //Assert
+            this.metaDataStoreMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), string.Empty), Times.Once());
+        }
     }
 }

--- a/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
+++ b/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
@@ -3,6 +3,7 @@ using MLOps.NET.Storage;
 using MLOps.NET.Utilities;
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace MLOps.NET.Catalogs
@@ -40,21 +41,23 @@ namespace MLOps.NET.Catalogs
         /// Creates a unique run for a given experiment
         /// </summary>
         /// <param name="experimentId"></param>
+        /// <param name="gitCommitHash">Optional, set the linked git commit hash</param>
         /// <returns>Run Id</returns>
-        public async Task<Guid> CreateRunAsync(Guid experimentId)
+        public async Task<Guid> CreateRunAsync(Guid experimentId, string gitCommitHash = "")
         {
-            return await metaDataStore.CreateRunAsync(experimentId);
+            return await metaDataStore.CreateRunAsync(experimentId, gitCommitHash);
         }
 
         /// <summary>
         /// Creates a unique run and experiment given an experiment name
         /// </summary>
         /// <param name="experimentName"></param>
+        /// <param name="gitCommitHash">Optional, set the linked git commit hash</param>
         /// <returns>Run Id</returns>
-        public async Task<Guid> CreateRunAsync(string experimentName)
+        public async Task<Guid> CreateRunAsync(string experimentName, string gitCommitHash = "")
         {
             var experimentId = await CreateExperimentAsync(experimentName);
-            return await CreateRunAsync(experimentId);
+            return await CreateRunAsync(experimentId, gitCommitHash);
         }
 
         /// <summary>

--- a/src/MLOps.NET/Entities/Interfaces/IRun.cs
+++ b/src/MLOps.NET/Entities/Interfaces/IRun.cs
@@ -31,5 +31,10 @@ namespace MLOps.NET.Entities.Entities
         /// Training time
         /// </summary>
         TimeSpan TrainingTime { get; set; }
+
+        /// <summary>
+        /// Git Commit Hash
+        /// </summary>
+        string GitCommitHash { get; set; }
     }
 }

--- a/src/MLOps.NET/Storage/Interfaces/IMetaDataStore.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IMetaDataStore.cs
@@ -16,13 +16,14 @@ namespace MLOps.NET.Storage
         /// <param name="name"></param>
         /// <returns></returns>
         Task<Guid> CreateExperimentAsync(string name);
-       
+
         /// <summary>
         /// Creates a unqiue run for a given experiment
         /// </summary>
         /// <param name="experimentId"></param>
+        /// <param name="gitCommitHash">Optional, sets the linked git commit hash</param>
         /// <returns></returns>
-        Task<Guid> CreateRunAsync(Guid experimentId);
+        Task<Guid> CreateRunAsync(Guid experimentId, string gitCommitHash = "");
         
         /// <summary>
         /// Logs a given metric for a run


### PR DESCRIPTION
## Resolves
Fixes #58 

## Description
Added a simple way to associate a Git Commit with a Run. We want to potentially do this in a different going forward with an MLOps CLI tool, but this is a simple solution to start with.