### PR TITLE
#136 - The SQLite Storage Provider is creating duplicate experiments

### DIFF
--- a/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
+++ b/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
@@ -16,11 +16,17 @@ namespace MLOps.NET.Storage
         {
             using (var db = new LocalDbContext())
             {
-                var experiment = new Experiment(name);
-                await db.Experiments.AddAsync(experiment);
-                await db.SaveChangesAsync();
-                
-                return experiment.Id;
+	            var existingExperiment = db.Experiments.FirstOrDefault(x => x.ExperimentName == name);
+
+	            if (existingExperiment == null)
+	            {
+		            var experiment = new Experiment(name);
+		            await db.Experiments.AddAsync(experiment);
+		            await db.SaveChangesAsync();
+		            return experiment.Id;
+                }
+
+	            return existingExperiment.Id;
             }
         }
 

--- a/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
+++ b/src/MLOps.NET.SQLite/Storage/SQLiteMetaDataStore.cs
@@ -16,17 +16,17 @@ namespace MLOps.NET.Storage
         {
             using (var db = new LocalDbContext())
             {
-	            var existingExperiment = db.Experiments.FirstOrDefault(x => x.ExperimentName == name);
+                var existingExperiment = db.Experiments.FirstOrDefault(x => x.ExperimentName == name);
 
-	            if (existingExperiment == null)
-	            {
-		            var experiment = new Experiment(name);
-		            await db.Experiments.AddAsync(experiment);
-		            await db.SaveChangesAsync();
-		            return experiment.Id;
+                if (existingExperiment == null)
+                {
+                    var experiment = new Experiment(name);
+                    await db.Experiments.AddAsync(experiment);
+                    await db.SaveChangesAsync();
+                    return experiment.Id;
                 }
 
-	            return existingExperiment.Id;
+                return existingExperiment.Id;
             }
         }
 

--- a/test/MLOps.NET.SQLite.IntegrationTests/SQLiteMetaDataStoreTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/SQLiteMetaDataStoreTests.cs
@@ -136,6 +136,23 @@ namespace MLOps.NET.SQLite.IntegrationTests
             run.GitCommitHash.Should().Be(string.Empty);
         }
 
+        [TestMethod]
+        public async Task CreateExperimentAsync_Twice_ShouldNotAddDuplicate()
+        {
+            // Arrange
+            var sut = new MLOpsBuilder()
+	            .UseSQLite()
+	            .UseModelRepository(new Mock<IModelRepository>().Object)
+	            .Build();
+
+            //Act
+            var experimentId = await sut.LifeCycle.CreateExperimentAsync("test");
+	        var experimentId2 = await sut.LifeCycle.CreateExperimentAsync("test");
+
+	        //Assert
+	        experimentId.Should().Be(experimentId2);
+        }
+
         private static List<DataPoint> GetSampleDataForTraining()
         {
             return new List<DataPoint>()

--- a/test/MLOps.NET.SQLite.IntegrationTests/SQLiteMetaDataStoreTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/SQLiteMetaDataStoreTests.cs
@@ -141,16 +141,16 @@ namespace MLOps.NET.SQLite.IntegrationTests
         {
             // Arrange
             var sut = new MLOpsBuilder()
-	            .UseSQLite()
-	            .UseModelRepository(new Mock<IModelRepository>().Object)
-	            .Build();
+                .UseSQLite()
+                .UseModelRepository(new Mock<IModelRepository>().Object)
+                .Build();
 
             //Act
             var experimentId = await sut.LifeCycle.CreateExperimentAsync("test");
-	        var experimentId2 = await sut.LifeCycle.CreateExperimentAsync("test");
+            var experimentId2 = await sut.LifeCycle.CreateExperimentAsync("test");
 
-	        //Assert
-	        experimentId.Should().Be(experimentId2);
+            //Assert
+            experimentId.Should().Be(experimentId2);
         }
 
         private static List<DataPoint> GetSampleDataForTraining()


### PR DESCRIPTION
## Resolves
Fixes #136 

## Description
Added a new test for the issue and implemented the duplicate check on CreateExperimentAsync for SQLiteMetaDataStore.
