### PR TITLE
Added ability to get run by git commit hash

### DIFF
--- a/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
+++ b/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
@@ -80,6 +80,16 @@ namespace MLOps.NET.Catalogs
         }
 
         /// <summary>
+        /// Get a run by commit hash
+        /// </summary>
+        /// <param name="commitHash"></param>
+        /// <returns></returns>
+        public IRun GetRun(string commitHash)
+        {
+            return this.metaDataStore.GetRun(commitHash);
+        }
+
+        /// <summary>
         /// Gets the best run for an experiment based on a metric for e.g "Accuracy"
         /// </summary>
         /// <param name="experimentId"></param>

--- a/src/MLOps.NET/Storage/Interfaces/IMetaDataStore.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IMetaDataStore.cs
@@ -65,6 +65,13 @@ namespace MLOps.NET.Storage
         IRun GetRun(Guid runId);
 
         /// <summary>
+        /// Get a run by commit hash
+        /// </summary>
+        /// <param name="commitHash"></param>
+        /// <returns></returns>
+        IRun GetRun(string commitHash);
+
+        /// <summary>
         /// Saves the confusion matrix as a json serialized string
         /// </summary>
         /// <param name="runId"></param>

--- a/src/MLOps.NET/Storage/MetaDataStore/MetaDataStore.cs
+++ b/src/MLOps.NET/Storage/MetaDataStore/MetaDataStore.cs
@@ -94,6 +94,15 @@ namespace MLOps.NET.Storage
         }
 
         ///<inheritdoc cref="IMetaDataStore"/>
+        public IRun GetRun(string commitHash)
+        {
+            using (var db = this.contextFactory.CreateDbContext())
+            {
+                return db.Runs.FirstOrDefault(x => x.GitCommitHash == commitHash);
+            }
+        }
+
+        ///<inheritdoc cref="IMetaDataStore"/>
         public List<IRun> GetRuns(Guid experimentId)
         {
             using (var db = this.contextFactory.CreateDbContext())

--- a/test/MLOps.NET.Azure.IntegrationTests/MetaDataStoreTests.cs
+++ b/test/MLOps.NET.Azure.IntegrationTests/MetaDataStoreTests.cs
@@ -177,6 +177,20 @@ namespace MLOps.NET.Azure.IntegrationTests
                 .BeTrue();
         }
 
+        [TestMethod]
+        public async Task GivenARunWithGitCommitHash_ShouldBeAbleToGetRun()
+        {
+            //Arrange
+            var commitHash = "123456789";
+            var runId = await sut.LifeCycle.CreateRunAsync("Experiment", commitHash);
+
+            //Act
+            var savedRun = sut.LifeCycle.GetRun(commitHash);
+
+            //Assert
+            savedRun.Id.Should().Be(runId);
+        }
+
         private IDataView LoadData()
         {
             var mlContext = new MLContext(seed: 1);

--- a/test/MLOps.NET.SQLServer.IntegrationTests/MetaDataStoreTests.cs
+++ b/test/MLOps.NET.SQLServer.IntegrationTests/MetaDataStoreTests.cs
@@ -128,6 +128,20 @@ namespace MLOps.NET.SQLServer.IntegrationTests
             run.TrainingTime.Should().Be(trainingTime);
         }
 
+        [TestMethod]
+        public async Task GivenARunWithGitCommitHash_ShouldBeAbleToGetRun()
+        {
+            //Arrange
+            var commitHash = "123456789";
+            var runId = await sut.LifeCycle.CreateRunAsync("Experiment", commitHash);
+
+            //Act
+            var savedRun = sut.LifeCycle.GetRun(commitHash);
+
+            //Assert
+            savedRun.Id.Should().Be(runId);
+        }
+
         //[TestMethod]
         //public async Task LogConfusionMatrixAsync_SavesConfusionMatrixOnRun()
         //{

--- a/test/MLOps.NET.SQLite.IntegrationTests/MetaDataStoreTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/MetaDataStoreTests.cs
@@ -151,6 +151,20 @@ namespace MLOps.NET.SQLite.IntegrationTests
                 .BeTrue();
         }
 
+        [TestMethod]
+        public async Task GivenARunWithGitCommitHash_ShouldBeAbleToGetRun()
+        {
+            //Arrange
+            var commitHash = "123456789";
+            var runId = await sut.LifeCycle.CreateRunAsync("Experiment", commitHash);
+
+            //Act
+            var savedRun = sut.LifeCycle.GetRun(commitHash);
+
+            //Assert
+            savedRun.Id.Should().Be(runId);
+        }
+
         private IDataView LoadData()
         {
             var mlContext = new MLContext(seed: 1);


### PR DESCRIPTION
## Resolves
Fixes #194 

## Description
This method will be useful when we for example run model tests as we can fetch a run and the model by just using the git commit hash which we easily can get from the github actions workflow. We can then compare things such as model performance or run our own model tests.
