### PR TITLE
Added ability to automatically migrate the relational schema

### DIFF
--- a/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
@@ -38,7 +38,7 @@ namespace MLOps.NET.Storage.Database
         /// <returns></returns>
         public void EnsureCreated()
         {
-            Database.EnsureCreated();
+            Database.Migrate();
         }
 
         ///<inheritdoc cref="IMLOpsDbContext"/>


### PR DESCRIPTION
## Resolves
Fixes #120 

## Description
`EnsureCreated` and `Migrate` are mutually exlusive, and `Migrate` will both create the database if it does not exist and migrate the schema if required. For now, we'll use automatic migration.
