### PR TITLE
Updated version.json

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3.0-beta.{height}",
+  "version": "0.3.1-beta.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",


### PR DESCRIPTION
Apologies for the spamming last night, I was trying to figure out a good automated process to release and push our packages to nuget.org. 

I think I got it now, and  just released v0.3.0-beta!

The process for a release is:
- Create a release branch named e.g. release/0.3.0
- Update the `version.json` for that branch to skip the build number (and beta if it's not a pre-release)
- Push changes to git
- Create a new release in GitHub with name "Release v0.3.0-beta" and tag `v0.3.0-beta`
- Publish the release
- This will automatically kick of `release.nuget.yml` which will push the packages to nuget.org
- Update the `version.json` on the main branch to increment at least the path number, third digit.