### PR TITLE
Added support for deployment targets

### DIFF
--- a/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
+++ b/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MLOps.NET.Entities.Impl;
-using System.Security.Cryptography.X509Certificates;
 
 namespace MLOps.NET.Azure.Storage
 {
@@ -23,6 +22,7 @@ namespace MLOps.NET.Azure.Storage
             modelBuilder.Entity<Data>().ToContainer(nameof(Data));
             modelBuilder.Entity<RunArtifact>().ToContainer(nameof(RunArtifact));
             modelBuilder.Entity<RegisteredModel>().ToContainer(nameof(RegisteredModel));
+            modelBuilder.Entity<DeploymentTarget>().ToContainer(nameof(DeploymentTarget));
 
             modelBuilder.Entity<Data>().OwnsOne(x => x.DataSchema, dataSchema =>
             {

--- a/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
+++ b/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
@@ -1,0 +1,42 @@
+﻿using MLOps.NET.Entities.Impl;
+using MLOps.NET.Storage.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Catalogs
+{
+    /// <summary>
+    /// Exposes actions for deploying a model
+    /// </summary>
+    public sealed class DeploymentCatalog
+    {
+        private readonly IDeploymentRepository deploymentRepository;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="deploymentRepository"></param>
+        public DeploymentCatalog(IDeploymentRepository deploymentRepository)
+        {
+            this.deploymentRepository = deploymentRepository;
+        }
+
+        /// <summary>
+        /// Creates a deployment target
+        /// </summary>
+        /// <param name="deploymentTargetName"></param>
+        public async Task CreateDeploymentTargetAsync(string deploymentTargetName)
+        {
+            await this.deploymentRepository.CreateDeploymentTargetAsync(deploymentTargetName);
+        }
+
+        /// <summary>
+        /// Get deployment targets
+        /// </summary>
+        /// <returns></returns>
+        public List<DeploymentTarget> GetDeploymentTargets()
+        {
+            return this.deploymentRepository.GetDeploymentTargets();
+        }
+    }
+}

--- a/src/MLOps.NET/Entities/Impl/DeploymentTarget.cs
+++ b/src/MLOps.NET/Entities/Impl/DeploymentTarget.cs
@@ -13,14 +13,14 @@ namespace MLOps.NET.Entities.Impl
         /// <param name="name"></param>
         public DeploymentTarget(string name)
         {
-            Id = Guid.NewGuid();
+            DeploymentTargetId = Guid.NewGuid();
             Name = name;
         }
 
         /// <summary>
         /// Id
         /// </summary>
-        public Guid Id { get; set; }
+        public Guid DeploymentTargetId { get; set; }
 
         /// <summary>
         /// Name

--- a/src/MLOps.NET/Entities/Impl/DeploymentTarget.cs
+++ b/src/MLOps.NET/Entities/Impl/DeploymentTarget.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace MLOps.NET.Entities.Impl
+{
+    /// <summary>
+    /// Entity describing a deployment target
+    /// </summary>
+    public sealed class DeploymentTarget
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="name"></param>
+        public DeploymentTarget(string name)
+        {
+            Id = Guid.NewGuid();
+            Name = name;
+        }
+
+        /// <summary>
+        /// Id
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// CreatedDate
+        /// </summary>
+        public DateTime CreatedDate { get; set; }
+    }
+}

--- a/src/MLOps.NET/IMLOpsContext.cs
+++ b/src/MLOps.NET/IMLOpsContext.cs
@@ -34,5 +34,10 @@ namespace MLOps.NET
         /// Operations related to the training of a model
         /// </summary>
         TrainingCatalog Training { get; }
+
+        /// <summary>
+        /// Operations related to the deployment of a model
+        /// </summary>
+        DeploymentCatalog Deployment { get; }
     }
 }

--- a/src/MLOps.NET/MLOpsBuilder.cs
+++ b/src/MLOps.NET/MLOpsBuilder.cs
@@ -1,5 +1,6 @@
 using MLOps.NET.Storage;
 using MLOps.NET.Storage.Database;
+using MLOps.NET.Storage.Repositories;
 using MLOps.NET.Utilities;
 using System;
 
@@ -16,7 +17,7 @@ namespace MLOps.NET
         private IMetricRepository metricRepository;
         private IConfusionMatrixRepository confusionMatrixRepository;
         private IHyperParameterRepository hyperParameterRepository;
-
+        private DeploymentRepository deploymentRepository;
         private IModelRepository modelRepository;
 
         /// <summary>
@@ -25,7 +26,7 @@ namespace MLOps.NET
         /// <returns>Configured <see cref="IMLOpsContext"/></returns>
         public IMLOpsContext Build()
         {
-            return new MLOpsContext(modelRepository, experimentRepository, runRepository, dataRepository, metricRepository, confusionMatrixRepository, hyperParameterRepository);
+            return new MLOpsContext(modelRepository, experimentRepository, runRepository, dataRepository, metricRepository, confusionMatrixRepository, hyperParameterRepository, deploymentRepository);
         }
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace MLOps.NET
             this.metricRepository = new MetricRepository(contextFactory);
             this.confusionMatrixRepository = new ConfusionMatrixRepository(contextFactory);
             this.hyperParameterRepository = new HyperParameterRepository(contextFactory);
+            this.deploymentRepository = new DeploymentRepository(contextFactory, new Clock());
 
             return this;
         }

--- a/src/MLOps.NET/MLOpsContext.cs
+++ b/src/MLOps.NET/MLOpsContext.cs
@@ -1,5 +1,6 @@
 ﻿using MLOps.NET.Catalogs;
 using MLOps.NET.Storage;
+using MLOps.NET.Storage.Interfaces;
 using MLOps.NET.Utilities;
 using System;
 
@@ -14,7 +15,8 @@ namespace MLOps.NET
             IDataRepository dataRepository,
             IMetricRepository metricRepository,
             IConfusionMatrixRepository confusionMatrixRepository,
-            IHyperParameterRepository hyperParameterRepository)
+            IHyperParameterRepository hyperParameterRepository,
+            IDeploymentRepository deploymentRepository)
         {
             if (modelRepository == null) throw new ArgumentNullException(nameof(modelRepository));
             if (experimentRepository == null) throw new ArgumentNullException(nameof(experimentRepository));
@@ -23,12 +25,14 @@ namespace MLOps.NET
             if (metricRepository == null) throw new ArgumentNullException(nameof(metricRepository));
             if (confusionMatrixRepository == null) throw new ArgumentNullException(nameof(confusionMatrixRepository));
             if (hyperParameterRepository == null) throw new ArgumentNullException(nameof(hyperParameterRepository));
+            if (deploymentRepository == null) throw new ArgumentNullException(nameof(deploymentRepository));
 
             this.LifeCycle = new LifeCycleCatalog(experimentRepository, runRepository, new Clock());
             this.Data = new DataCatalog(dataRepository);
             this.Evaluation = new EvaluationCatalog(metricRepository, confusionMatrixRepository);
             this.Model = new ModelCatalog(modelRepository, runRepository);
             this.Training = new TrainingCatalog(hyperParameterRepository);
+            this.Deployment = new DeploymentCatalog(deploymentRepository);
         }
 
         ///<inheritdoc cref="IMLOpsContext"/>
@@ -45,6 +49,9 @@ namespace MLOps.NET
 
         ///<inheritdoc cref="IMLOpsContext"/>
         public TrainingCatalog Training { get; private set; }
+
+        ///<inheritdoc cref="IMLOpsContext"/>
+        public DeploymentCatalog Deployment { get; set; }
 
     }
 }

--- a/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
@@ -34,6 +34,9 @@ namespace MLOps.NET.Storage.Database
                 .HasOne(x => x.Experiment)
                 .WithMany()
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<DeploymentTarget>()
+                .Property(x => x.Name).IsRequired();
         }
 
         ///<inheritdoc cref="IMLOpsDbContext"/>
@@ -74,5 +77,8 @@ namespace MLOps.NET.Storage.Database
 
         ///<inheritdoc cref="IMLOpsDbContext"/>
         public DbSet<RegisteredModel> RegisteredModels { get; set; }
+
+        ///<inheritdoc cref="IMLOpsDbContext"/>
+        public DbSet<DeploymentTarget> DeploymentTargets { get; set; }
     }
 }

--- a/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
+++ b/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
@@ -24,6 +24,7 @@ namespace MLOps.NET.Storage.EntityConfiguration
             modelBuilder.Entity<DataSchema>().ToTable(nameof(DataSchema));
             modelBuilder.Entity<RunArtifact>().ToTable(nameof(RunArtifact));
             modelBuilder.Entity<RegisteredModel>().ToTable(nameof(RegisteredModel));
+            modelBuilder.Entity<DeploymentTarget>().ToTable(nameof(DeploymentTarget));
         }
     }
 }

--- a/src/MLOps.NET/Storage/Interfaces/IDeploymentRepository.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IDeploymentRepository.cs
@@ -1,0 +1,24 @@
+﻿using MLOps.NET.Entities.Impl;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Storage.Interfaces
+{
+    /// <summary>
+    /// Repository to manage deployment related entities
+    /// </summary>
+    public interface IDeploymentRepository
+    {
+        /// <summary>
+        /// Creates a deployment target
+        /// </summary>
+        /// <param name="deploymentTargetName"></param>
+        Task CreateDeploymentTargetAsync(string deploymentTargetName);
+
+        /// <summary>
+        /// Gets all deployment targets
+        /// </summary>
+        /// <returns></returns>
+        List<DeploymentTarget> GetDeploymentTargets();
+    }
+}

--- a/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
@@ -51,6 +51,11 @@ namespace MLOps.NET.Storage.Interfaces
         DbSet<RegisteredModel> RegisteredModels { get; set; }
 
         /// <summary>
+        /// DeploymentTargets
+        /// </summary>
+        DbSet<DeploymentTarget> DeploymentTargets { get; set; }
+
+        /// <summary>
         /// Save changes
         /// </summary>
         /// <returns></returns>

--- a/src/MLOps.NET/Storage/Repositories/DeploymentRepository.cs
+++ b/src/MLOps.NET/Storage/Repositories/DeploymentRepository.cs
@@ -1,0 +1,53 @@
+﻿using MLOps.NET.Entities.Impl;
+using MLOps.NET.Storage.Database;
+using MLOps.NET.Storage.Interfaces;
+using MLOps.NET.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Storage.Repositories
+{
+    ///<inheritdoc cref="IDeploymentRepository"/>
+    public sealed class DeploymentRepository : IDeploymentRepository
+    {
+        private readonly IDbContextFactory contextFactory;
+        private readonly IClock clock;
+
+        ///<inheritdoc cref="IDeploymentRepository"/>
+        public DeploymentRepository(IDbContextFactory contextFactory, IClock clock)
+        {
+            this.contextFactory = contextFactory;
+            this.clock = clock;
+        }
+
+        ///<inheritdoc cref="IDeploymentRepository"/>
+        public async Task CreateDeploymentTargetAsync(string deploymentTargetName)
+        {
+            if (string.IsNullOrEmpty(deploymentTargetName))
+            {
+                throw new ArgumentNullException("Deployment target name was not specified");
+            }
+
+            using var db = this.contextFactory.CreateDbContext();
+
+            var deploymentTarget = new DeploymentTarget(deploymentTargetName)
+            {
+                CreatedDate = clock.UtcNow
+            };
+
+            db.DeploymentTargets.Add(deploymentTarget);
+
+            await db.SaveChangesAsync();
+        }
+
+        ///<inheritdoc cref="IDeploymentRepository"/>
+        public List<DeploymentTarget> GetDeploymentTargets()
+        {
+            using var db = this.contextFactory.CreateDbContext();
+
+            return db.DeploymentTargets.ToList();
+        }
+    }
+}

--- a/test/MLOps.NET.Azure.IntegrationTests/AzureLifeDeploymentCatalogTests.cs
+++ b/test/MLOps.NET.Azure.IntegrationTests/AzureLifeDeploymentCatalogTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MLOps.NET.IntegrationTests;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Azure.IntegrationTests
+{
+    [TestClass]
+    [TestCategory("IntegrationTestCosmosDb")]
+    public class AzureDeploymentCatalogTests : DeploymentCatalogTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            sut = IntegrationTestSetup.Initialize();
+        }
+
+        [TestCleanup]
+        public async Task TearDown()
+        {
+            var context = IntegrationTestSetup.CreateDbContext();
+
+            await base.TearDown(context);
+        }
+    }
+}

--- a/test/MLOps.NET.IntegrationTests/DeploymentCatalogTests.cs
+++ b/test/MLOps.NET.IntegrationTests/DeploymentCatalogTests.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.IntegrationTests
+{
+    public class DeploymentCatalogTests : RepositoryTests
+    {
+        [TestMethod]
+        public async Task CreateDeploymentTarget_GivenName_CreatesAValidDeploymentTarget()
+        {
+            //Act
+            await sut.Deployment.CreateDeploymentTargetAsync("Production");
+
+            //Assert
+            var deploymentTargets = sut.Deployment.GetDeploymentTargets();
+            deploymentTargets.First().Name.Should().Be("Production");
+            deploymentTargets.First().CreatedDate.Date.Should().Be(DateTime.Now.Date);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException), "Deployment target name was not specified")]
+        public async Task CreateDeploymentTarget_GivenNameIsNullOrEmpty_ThrowsExceptionWithMessage()
+        {
+            //Act
+            await sut.Deployment.CreateDeploymentTargetAsync(null);
+        }
+    }
+}

--- a/test/MLOps.NET.IntegrationTests/RepositoryTests.cs
+++ b/test/MLOps.NET.IntegrationTests/RepositoryTests.cs
@@ -9,23 +9,15 @@ namespace MLOps.NET.IntegrationTests
 
         protected async Task TearDown(IMLOpsDbContext context)
         {
-            var experiments = context.Experiments;
-            var runs = context.Runs;
-            var metrics = context.Metrics;
-            var hyperParameters = context.HyperParameters;
-            var confusionMatrices = context.ConfusionMatrices;
-            var data = context.Data;
-            var runArtifacts = context.RunArtifacts;
-            var registeredModels = context.RegisteredModels;
-
-            context.Experiments.RemoveRange(experiments);
-            context.Runs.RemoveRange(runs);
-            context.Metrics.RemoveRange(metrics);
-            context.HyperParameters.RemoveRange(hyperParameters);
-            context.ConfusionMatrices.RemoveRange(confusionMatrices);
-            context.Data.RemoveRange(data);
-            context.RunArtifacts.RemoveRange(runArtifacts);
-            context.RegisteredModels.RemoveRange(registeredModels);
+            context.Experiments.RemoveRange(context.Experiments);
+            context.Runs.RemoveRange(context.Runs);
+            context.Metrics.RemoveRange(context.Metrics);
+            context.HyperParameters.RemoveRange(context.HyperParameters);
+            context.ConfusionMatrices.RemoveRange(context.ConfusionMatrices);
+            context.Data.RemoveRange(context.Data);
+            context.RunArtifacts.RemoveRange(context.RunArtifacts);
+            context.RegisteredModels.RemoveRange(context.RegisteredModels);
+            context.DeploymentTargets.RemoveRange(context.DeploymentTargets);
 
             await context.SaveChangesAsync();
         }

--- a/test/MLOps.NET.SQLServer.IntegrationTests/SQLServerDeploymentCatalogTests.cs
+++ b/test/MLOps.NET.SQLServer.IntegrationTests/SQLServerDeploymentCatalogTests.cs
@@ -6,7 +6,7 @@ namespace MLOps.NET.SQLServer.IntegrationTests
 {
     [TestClass]
     [TestCategory("IntegrationTestSqlServer")]
-    public class SQLServerDeploymentCatalogTestsTests : DeploymentCatalogTests
+    public class SQLServerDeploymentCatalogTests : DeploymentCatalogTests
     {
         [TestInitialize]
         public void Initialize()

--- a/test/MLOps.NET.SQLServer.IntegrationTests/SQLServerDeploymentCatalogTestsTests.cs
+++ b/test/MLOps.NET.SQLServer.IntegrationTests/SQLServerDeploymentCatalogTestsTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MLOps.NET.IntegrationTests;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.SQLServer.IntegrationTests
+{
+    [TestClass]
+    [TestCategory("IntegrationTestSqlServer")]
+    public class SQLServerDeploymentCatalogTestsTests : DeploymentCatalogTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            sut = IntegrationTestSetup.Initialize();
+        }
+
+        [TestCleanup]
+        public async Task TearDown()
+        {
+            var context = IntegrationTestSetup.CreateDbContext();
+
+            await base.TearDown(context);
+        }
+    }
+}

--- a/test/MLOps.NET.SQLite.IntegrationTests/SQLiteDeploymentCatalogTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/SQLiteDeploymentCatalogTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MLOps.NET.IntegrationTests;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.SQLite.IntegrationTests
+{
+    [TestCategory("Integration")]
+    [TestClass]
+    public class SQLiteDeploymentCatalogTests : DeploymentCatalogTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            sut = IntegrationTestSetup.Initialize();
+        }
+
+        [TestCleanup]
+        public async Task TearDown()
+        {
+            var context = IntegrationTestSetup.CreateDbContext();
+
+            await base.TearDown(context);
+        }
+    }
+}

--- a/test/MLOps.NET.Tests/Repositories/DeploymentRepositoryTests.cs
+++ b/test/MLOps.NET.Tests/Repositories/DeploymentRepositoryTests.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MLOps.NET.Storage.Database;
+using MLOps.NET.Storage.EntityConfiguration;
+using MLOps.NET.Storage.Interfaces;
+using MLOps.NET.Storage.Repositories;
+using MLOps.NET.Utilities;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MLOps.NET.Tests
+{
+    [TestCategory("UnitTests")]
+    [TestClass]
+    public class DeploymentRepositoryTests
+    {
+        private Mock<IClock> clockMock;
+        private DbContextFactory contextFactory;
+        private IDeploymentRepository sut;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<MLOpsDbContext>()
+                .UseInMemoryDatabase(databaseName: "MLOpsNET")
+                .Options;
+
+            this.contextFactory = new DbContextFactory(options, RelationalEntityConfigurator.OnModelCreating);
+
+            this.clockMock = new Mock<IClock>();
+
+            this.sut = new DeploymentRepository(contextFactory, clockMock.Object);
+        }
+
+        [TestMethod]
+        public async Task CreateDeploymentTarget_ShouldSetCreatedDate()
+        {
+            //Arrange
+            var now = DateTime.Now;
+            this.clockMock.Setup(x => x.UtcNow).Returns(now);
+
+            //Act
+            await this.sut.CreateDeploymentTargetAsync("Production");
+
+            //Assert
+            using var db = this.contextFactory.CreateDbContext();
+            var deploymentTarget = db.DeploymentTargets.First();
+
+            deploymentTarget.CreatedDate.Should().Be(now);
+        }
+    }
+}

--- a/test/MLOps.NET.Tests/Repositories/RunRepositoryTests.cs
+++ b/test/MLOps.NET.Tests/Repositories/RunRepositoryTests.cs
@@ -15,11 +15,11 @@ namespace MLOps.NET.Tests
 {
     [TestCategory("UnitTests")]
     [TestClass]
-    public class ModelCatalogTests
+    public class RunRepositoryTests
     {
         private Mock<IClock> clockMock;
         private DbContextFactory contextFactory;
-        private RunRepository sut;
+        private IRunRepository sut;
 
         [TestInitialize]
         public void Initialize()


### PR DESCRIPTION
## Resolves
Fixes #148 

## Description
Added very simple functionality to specify the name of a deployment target, which normally would end up being 'Test', 'Stage' or for example 'Production'
