### PR TITLE
Adding the ability to detect and save PackageDependencies for a Run

### DIFF
--- a/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
+++ b/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
@@ -27,7 +27,7 @@ namespace MLOps.NET.Azure.Storage
             modelBuilder.Entity<RegisteredModel>().ToContainer(nameof(RegisteredModel));
             modelBuilder.Entity<DeploymentTarget>().ToContainer(nameof(DeploymentTarget));
             modelBuilder.Entity<Deployment>().ToContainer(nameof(Deployment));
-            modelBuilder.Entity<PackageDepedency>().ToContainer(nameof(PackageDepedency));
+            modelBuilder.Entity<PackageDependency>().ToContainer(nameof(PackageDependency));
         }
     }
 }

--- a/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
+++ b/src/MLOps.NET.Azure/Storage/CosmosEntityConfigurator.cs
@@ -27,6 +27,7 @@ namespace MLOps.NET.Azure.Storage
             modelBuilder.Entity<RegisteredModel>().ToContainer(nameof(RegisteredModel));
             modelBuilder.Entity<DeploymentTarget>().ToContainer(nameof(DeploymentTarget));
             modelBuilder.Entity<Deployment>().ToContainer(nameof(Deployment));
+            modelBuilder.Entity<PackageDepedency>().ToContainer(nameof(PackageDepedency));
         }
     }
 }

--- a/src/MLOps.NET.SQLServer/Migrations/20201001214039_AddPackageDependency.Designer.cs
+++ b/src/MLOps.NET.SQLServer/Migrations/20201001214039_AddPackageDependency.Designer.cs
@@ -4,14 +4,20 @@ using MLOps.NET.SQLServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace MLOps.NET.SQLServer.Migrations
 {
     [DbContext(typeof(MLOpsSQLDbContext))]
-    partial class MLOpsSQLDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201001214039_AddPackageDependency")]
+    partial class AddPackageDependency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="modelBuilder"></param>
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MLOps.NET.SQLServer/Migrations/20201001214039_AddPackageDependency.cs
+++ b/src/MLOps.NET.SQLServer/Migrations/20201001214039_AddPackageDependency.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MLOps.NET.SQLServer.Migrations
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public partial class AddPackageDependency : Migration
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="migrationBuilder"></param>
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PackageDependency",
+                columns: table => new
+                {
+                    PackageDependencyId = table.Column<Guid>(nullable: false),
+                    RunId = table.Column<Guid>(nullable: false),
+                    Name = table.Column<string>(nullable: false),
+                    Version = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PackageDependency", x => x.PackageDependencyId);
+                    table.ForeignKey(
+                        name: "FK_PackageDependency_Run_RunId",
+                        column: x => x.RunId,
+                        principalTable: "Run",
+                        principalColumn: "RunId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackageDependency_RunId",
+                table: "PackageDependency",
+                column: "RunId");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="migrationBuilder"></param>
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PackageDependency");
+        }
+    }
+}

--- a/src/MLOps.NET.SQLite/Migrations/20201001211212_AddPackageDependency.Designer.cs
+++ b/src/MLOps.NET.SQLite/Migrations/20201001211212_AddPackageDependency.Designer.cs
@@ -3,14 +3,23 @@ using System;
 using MLOps.NET.SQLite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace MLOps.NET.SQLite.Migrations
 {
+    /// <summary>
+    /// 
+    /// </summary>
     [DbContext(typeof(MLOpsSQLiteDbContext))]
-    partial class MLOpsSQLiteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201001211212_AddPackageDependency")]
+    partial class AddPackageDependency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="modelBuilder"></param>
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MLOps.NET.SQLite/Migrations/20201001211212_AddPackageDependency.cs
+++ b/src/MLOps.NET.SQLite/Migrations/20201001211212_AddPackageDependency.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MLOps.NET.SQLite.Migrations
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public partial class AddPackageDependency : Migration
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="migrationBuilder"></param>
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PackageDependency",
+                columns: table => new
+                {
+                    PackageDependencyId = table.Column<Guid>(nullable: false),
+                    RunId = table.Column<Guid>(nullable: false),
+                    Name = table.Column<string>(nullable: false),
+                    Version = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PackageDependency", x => x.PackageDependencyId);
+                    table.ForeignKey(
+                        name: "FK_PackageDependency_Run_RunId",
+                        column: x => x.RunId,
+                        principalTable: "Run",
+                        principalColumn: "RunId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackageDependency_RunId",
+                table: "PackageDependency",
+                column: "RunId");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="migrationBuilder"></param>
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PackageDependency");
+        }
+    }
+}

--- a/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
+++ b/src/MLOps.NET/Catalogs/LifeCycleCatalog.cs
@@ -1,4 +1,5 @@
 ﻿using MLOps.NET.Entities.Impl;
+using MLOps.NET.Services.Interfaces;
 using MLOps.NET.Storage;
 using MLOps.NET.Utilities;
 using System;
@@ -15,6 +16,7 @@ namespace MLOps.NET.Catalogs
         private readonly IExperimentRepository experimentRepository;
         private readonly IRunRepository runRepository;
         private readonly IClock clock;
+        private readonly IPackageDependencyIdentifier packageDependencyIdentifier;
 
         /// <summary>
         /// ctor       
@@ -22,11 +24,16 @@ namespace MLOps.NET.Catalogs
         /// <param name="experimentRepository"></param>
         /// <param name="runRepository"></param>
         /// <param name="clock">Abstraction of DateTime</param>
-        public LifeCycleCatalog(IExperimentRepository experimentRepository, IRunRepository runRepository, IClock clock)
+        /// <param name="packageDependencyIdentifier"></param>
+        public LifeCycleCatalog(IExperimentRepository experimentRepository, 
+            IRunRepository runRepository, 
+            IClock clock,
+            IPackageDependencyIdentifier packageDependencyIdentifier)
         {
             this.experimentRepository = experimentRepository;
             this.runRepository = runRepository;
             this.clock = clock;
+            this.packageDependencyIdentifier = packageDependencyIdentifier;
         }
 
         /// <summary>
@@ -47,7 +54,9 @@ namespace MLOps.NET.Catalogs
         /// <returns>The created run</returns>
         public async Task<Run> CreateRunAsync(Guid experimentId, string gitCommitHash = "")
         {
-            return await runRepository.CreateRunAsync(experimentId, gitCommitHash);
+            var dependencies = packageDependencyIdentifier.IdentifyPackageDependencies();
+
+            return await runRepository.CreateRunAsync(experimentId, dependencies, gitCommitHash);
         }
 
         /// <summary>

--- a/src/MLOps.NET/Entities/Impl/PackageDepedency.cs
+++ b/src/MLOps.NET/Entities/Impl/PackageDepedency.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace MLOps.NET.Entities.Impl
+{
+    /// <summary>
+    /// Entity holding information about a package dependency
+    /// </summary>
+    public sealed class PackageDepedency
+    {
+        /// <summary>
+        /// PackageDepedencyId
+        /// </summary>
+        public Guid PackageDependencyId { get; set; }
+
+        /// <summary>
+        /// Associated RunId
+        /// </summary>
+        public Guid RunId { get; set; }
+
+        /// <summary>
+        /// Package Dependency Name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Package Dependency Version
+        /// </summary>
+        public string Version { get; set; }
+    }
+}

--- a/src/MLOps.NET/Entities/Impl/PackageDependency.cs
+++ b/src/MLOps.NET/Entities/Impl/PackageDependency.cs
@@ -5,7 +5,7 @@ namespace MLOps.NET.Entities.Impl
     /// <summary>
     /// Entity holding information about a package dependency
     /// </summary>
-    public sealed class PackageDepedency
+    public sealed class PackageDependency
     {
         /// <summary>
         /// PackageDepedencyId

--- a/src/MLOps.NET/Entities/Impl/Run.cs
+++ b/src/MLOps.NET/Entities/Impl/Run.cs
@@ -55,6 +55,11 @@ namespace MLOps.NET.Entities.Impl
         public List<RunArtifact> RunArtifacts { get; set; } = new List<RunArtifact>();
 
         /// <summary>
+        /// Package dependencies
+        /// </summary>
+        public List<PackageDepedency> PackageDepedencies { get; set; }
+
+        /// <summary>
         /// TrainingTime
         /// </summary>
         public TimeSpan? TrainingTime { get; set; }

--- a/src/MLOps.NET/Entities/Impl/Run.cs
+++ b/src/MLOps.NET/Entities/Impl/Run.cs
@@ -57,7 +57,7 @@ namespace MLOps.NET.Entities.Impl
         /// <summary>
         /// Package dependencies
         /// </summary>
-        public List<PackageDepedency> PackageDepedencies { get; set; }
+        public List<PackageDependency> PackageDepedencies { get; set; }
 
         /// <summary>
         /// TrainingTime

--- a/src/MLOps.NET/MLOps.NET.csproj
+++ b/src/MLOps.NET/MLOps.NET.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="CliWrap" Version="3.2.0" />
     <PackageReference Include="Dynamitey" Version="2.0.10.189" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="6.2.0.6124" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
     <PackageReference Include="Microsoft.ML" Version="1.5.2" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />

--- a/src/MLOps.NET/MLOpsContext.cs
+++ b/src/MLOps.NET/MLOpsContext.cs
@@ -32,7 +32,7 @@ namespace MLOps.NET
             if (hyperParameterRepository == null) throw new ArgumentNullException(nameof(hyperParameterRepository));
             if (deploymentRepository == null) throw new ArgumentNullException(nameof(deploymentRepository));
 
-            this.LifeCycle = new LifeCycleCatalog(experimentRepository, runRepository, new Clock());
+            this.LifeCycle = new LifeCycleCatalog(experimentRepository, runRepository, new Clock(), new PackageDependencyIdentifier());
             this.Data = new DataCatalog(dataRepository);
             this.Evaluation = new EvaluationCatalog(metricRepository, confusionMatrixRepository);
             this.Model = new ModelCatalog(modelRepository, runRepository);

--- a/src/MLOps.NET/Services/Interfaces/IPackageDependencyIdentifier.cs
+++ b/src/MLOps.NET/Services/Interfaces/IPackageDependencyIdentifier.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace MLOps.NET.Services.Interfaces
+{
+    /// <summary>
+    /// Identifies ML.NET Package Depedencies
+    /// </summary>
+    public interface IPackageDependencyIdentifier
+    {
+        /// <summary>
+        /// Identify ML.NET Package Dependencies
+        /// </summary>
+        /// <returns></returns>
+        List<(string Name, string Version)> IdentifyPackageDependencies();
+    }
+}

--- a/src/MLOps.NET/Services/Interfaces/IPackageDependencyIdentifier.cs
+++ b/src/MLOps.NET/Services/Interfaces/IPackageDependencyIdentifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using MLOps.NET.Entities.Impl;
+using System.Collections.Generic;
 
 namespace MLOps.NET.Services.Interfaces
 {
@@ -11,6 +12,6 @@ namespace MLOps.NET.Services.Interfaces
         /// Identify ML.NET Package Dependencies
         /// </summary>
         /// <returns></returns>
-        List<(string Name, string Version)> IdentifyPackageDependencies();
+        List<PackageDependency> IdentifyPackageDependencies();
     }
 }

--- a/src/MLOps.NET/Services/PackageDependencyIdentifier.cs
+++ b/src/MLOps.NET/Services/PackageDependencyIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyModel;
+using MLOps.NET.Entities.Impl;
 using MLOps.NET.Services.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +9,7 @@ namespace MLOps.NET.Services
 {
     internal sealed class PackageDependencyIdentifier : IPackageDependencyIdentifier
     {
-        public List<(string Name, string Version)> IdentifyPackageDependencies()
+        public List<PackageDependency> IdentifyPackageDependencies()
         {
             return DependencyContext.Load(Assembly.GetEntryAssembly())
                 .CompileLibraries
@@ -16,7 +17,11 @@ namespace MLOps.NET.Services
                 .Where(x => x.Type == "package")
                 .Select(x =>
                 {
-                    return (x.Name, x.Version);
+                    return new PackageDependency
+                    {
+                        Name = x.Name,
+                        Version = x.Version
+                    };
                 }).ToList();
         }
     }

--- a/src/MLOps.NET/Services/PackageDependencyIdentifier.cs
+++ b/src/MLOps.NET/Services/PackageDependencyIdentifier.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyModel;
+using MLOps.NET.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MLOps.NET.Services
+{
+    internal sealed class PackageDependencyIdentifier : IPackageDependencyIdentifier
+    {
+        public List<(string Name, string Version)> IdentifyPackageDependencies()
+        {
+            return DependencyContext.Load(Assembly.GetEntryAssembly())
+                .CompileLibraries
+                .Where(x => x.Name.Contains("Microsoft.ML"))
+                .Where(x => x.Type == "package")
+                .Select(x =>
+                {
+                    return (x.Name, x.Version);
+                }).ToList();
+        }
+    }
+}

--- a/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
@@ -79,5 +79,8 @@ namespace MLOps.NET.Storage.Database
 
         ///<inheritdoc cref="IMLOpsDbContext"/>
         public DbSet<Deployment> Deployments { get; set; }
+
+        ///<inheritdoc cref="IMLOpsDbContext"/>
+        public DbSet<PackageDepedency> PackageDependencies { get; set; }
     }
 }

--- a/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Database/MLOpsDbContext.cs
@@ -81,6 +81,6 @@ namespace MLOps.NET.Storage.Database
         public DbSet<Deployment> Deployments { get; set; }
 
         ///<inheritdoc cref="IMLOpsDbContext"/>
-        public DbSet<PackageDepedency> PackageDependencies { get; set; }
+        public DbSet<PackageDependency> PackageDependencies { get; set; }
     }
 }

--- a/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
+++ b/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
@@ -27,7 +27,7 @@ namespace MLOps.NET.Storage.EntityConfiguration
             modelBuilder.Entity<DeploymentTarget>().ToTable(nameof(DeploymentTarget));
             modelBuilder.Entity<Deployment>().ToTable(nameof(Deployment));
             modelBuilder.Entity<DataDistribution>().ToTable(nameof(DataDistribution));
-            modelBuilder.Entity<PackageDepedency>().ToTable(nameof(PackageDepedency));
+            modelBuilder.Entity<PackageDependency>().ToTable(nameof(PackageDependency));
         }
     }
 }

--- a/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
+++ b/src/MLOps.NET/Storage/EntityConfiguration/RelationalEntityConfigurator.cs
@@ -27,6 +27,7 @@ namespace MLOps.NET.Storage.EntityConfiguration
             modelBuilder.Entity<DeploymentTarget>().ToTable(nameof(DeploymentTarget));
             modelBuilder.Entity<Deployment>().ToTable(nameof(Deployment));
             modelBuilder.Entity<DataDistribution>().ToTable(nameof(DataDistribution));
+            modelBuilder.Entity<PackageDepedency>().ToTable(nameof(PackageDepedency));
         }
     }
 }

--- a/src/MLOps.NET/Storage/EntityMaps/PackageDependencyMap.cs
+++ b/src/MLOps.NET/Storage/EntityMaps/PackageDependencyMap.cs
@@ -4,9 +4,9 @@ using MLOps.NET.Entities.Impl;
 
 namespace MLOps.NET.Storage.EntityMaps
 {
-    internal sealed class PackageDependencyMap : IEntityTypeConfiguration<PackageDepedency>
+    internal sealed class PackageDependencyMap : IEntityTypeConfiguration<PackageDependency>
     {
-        public void Configure(EntityTypeBuilder<PackageDepedency> builder)
+        public void Configure(EntityTypeBuilder<PackageDependency> builder)
         {
             builder.Property(x => x.Name).IsRequired();
             builder.Property(x => x.Version).IsRequired();

--- a/src/MLOps.NET/Storage/EntityMaps/PackageDependencyMap.cs
+++ b/src/MLOps.NET/Storage/EntityMaps/PackageDependencyMap.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MLOps.NET.Entities.Impl;
+
+namespace MLOps.NET.Storage.EntityMaps
+{
+    internal sealed class PackageDependencyMap : IEntityTypeConfiguration<PackageDepedency>
+    {
+        public void Configure(EntityTypeBuilder<PackageDepedency> builder)
+        {
+            builder.Property(x => x.Name).IsRequired();
+            builder.Property(x => x.Version).IsRequired();
+        }
+    }
+}

--- a/src/MLOps.NET/Storage/EntityMaps/RunMap.cs
+++ b/src/MLOps.NET/Storage/EntityMaps/RunMap.cs
@@ -27,6 +27,11 @@ namespace MLOps.NET.Storage.EntityMaps
                 .HasForeignKey(x => x.RunId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            builder.HasMany(x => x.PackageDepedencies)
+                .WithOne()
+                .HasForeignKey(x => x.RunId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             builder.HasOne(x => x.ConfusionMatrix)
                 .WithOne()
                 .OnDelete(DeleteBehavior.Cascade);

--- a/src/MLOps.NET/Storage/EntityResolvers/RunResolver.cs
+++ b/src/MLOps.NET/Storage/EntityResolvers/RunResolver.cs
@@ -13,6 +13,7 @@ namespace MLOps.NET.Storage.EntityResolvers
             db.Entry(entity).Collection(x => x.Metrics).Load();
             db.Entry(entity).Reference(x => x.ConfusionMatrix).Load();
             db.Entry(entity).Collection(x => x.RunArtifacts).Load();
+            db.Entry(entity).Collection(x => x.PackageDepedencies).Load();
 
             return entity;
         }

--- a/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
@@ -67,6 +67,11 @@ namespace MLOps.NET.Storage.Interfaces
         DbSet<Deployment> Deployments { get; set; }
 
         /// <summary>
+        /// Package Dependencies
+        /// </summary>
+        DbSet<PackageDepedency> PackageDependencies { get; set; }
+
+        /// <summary>
         /// Save changes
         /// </summary>
         /// <returns></returns>

--- a/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IMLOpsDbContext.cs
@@ -69,7 +69,7 @@ namespace MLOps.NET.Storage.Interfaces
         /// <summary>
         /// Package Dependencies
         /// </summary>
-        DbSet<PackageDepedency> PackageDependencies { get; set; }
+        DbSet<PackageDependency> PackageDependencies { get; set; }
 
         /// <summary>
         /// Save changes

--- a/src/MLOps.NET/Storage/Interfaces/IRunRepository.cs
+++ b/src/MLOps.NET/Storage/Interfaces/IRunRepository.cs
@@ -14,10 +14,11 @@ namespace MLOps.NET.Storage
         /// Creates a unqiue run for a given experiment
         /// </summary>
         /// <param name="experimentId"></param>
+        /// <param name="packageDepedencies"></param>
         /// <param name="gitCommitHash">Optional, sets the linked git commit hash</param>
         /// <returns>Created run</returns>
         /// <returns></returns>
-        Task<Run> CreateRunAsync(Guid experimentId, string gitCommitHash = "");
+        Task<Run> CreateRunAsync(Guid experimentId, List<PackageDependency> packageDepedencies, string gitCommitHash = "");
 
         /// <summary>
         /// Get all runs by experiment id

--- a/src/MLOps.NET/Storage/Repositories/RunRepository.cs
+++ b/src/MLOps.NET/Storage/Repositories/RunRepository.cs
@@ -29,12 +29,13 @@ namespace MLOps.NET.Storage
         }
 
         ///<inheritdoc cref="IRunRepository"/>
-        public async Task<Run> CreateRunAsync(Guid experimentId, string gitCommitHash = "")
+        public async Task<Run> CreateRunAsync(Guid experimentId, List<PackageDependency> packageDepedencies, string gitCommitHash = "")
         {
             using var db = this.contextFactory.CreateDbContext();
             var run = new Run(experimentId)
             {
-                GitCommitHash = gitCommitHash
+                GitCommitHash = gitCommitHash,
+                PackageDepedencies = packageDepedencies
             };
 
             await db.Runs.AddAsync(run);

--- a/test/MLOps.NET.IntegrationTests/LifeCycleCatalogTests.cs
+++ b/test/MLOps.NET.IntegrationTests/LifeCycleCatalogTests.cs
@@ -123,5 +123,29 @@ namespace MLOps.NET.IntegrationTests
             //Assert
             experimentId.Should().Be(experimentId2);
         }
+
+        [TestMethod]
+        public async Task CreateRunAsync_GivenMLNETDependency_ShouldSetPackageDependencies()
+        {
+            var experimentId = await sut.LifeCycle.CreateExperimentAsync("test");
+
+            //Act
+            var run = await sut.LifeCycle.CreateRunAsync(experimentId);
+
+            //Assert
+            run = sut.LifeCycle.GetRun(run.RunId);
+            run.PackageDepedencies.Count().Should().BeGreaterThan(0);
+        }
+
+        [TestMethod]
+        public async Task CreateRunAndExperimentAsync_GivenMLNETDependency_ShouldSetPackageDependencies()
+        {
+            //Act
+            var run = await sut.LifeCycle.CreateRunAsync("test");
+
+            //Assert
+            run = sut.LifeCycle.GetRun(run.RunId);
+            run.PackageDepedencies.Count().Should().BeGreaterThan(0);
+        }
     }
 }

--- a/test/MLOps.NET.IntegrationTests/MLOps.NET.IntegrationTests.csproj
+++ b/test/MLOps.NET.IntegrationTests/MLOps.NET.IntegrationTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Microsoft.ML" Version="1.5.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/test/MLOps.NET.Tests/Catalogs/LifeCycleCatalogTests.cs
+++ b/test/MLOps.NET.Tests/Catalogs/LifeCycleCatalogTests.cs
@@ -29,6 +29,8 @@ namespace MLOps.NET.Tests
             this.runRepositoryMock = new Mock<IRunRepository>();
             this.packageDependencyMock = new Mock<IPackageDependencyIdentifier>();
 
+            packageDependencyMock.Setup(x => x.IdentifyPackageDependencies()).Returns(new List<PackageDependency>());
+
             this.sut = new LifeCycleCatalog(experimentRepositoryMock.Object, runRepositoryMock.Object, clockMock.Object, packageDependencyMock.Object);
         }
 
@@ -97,6 +99,28 @@ namespace MLOps.NET.Tests
 
             //Assert
             this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), new List<PackageDependency>(), string.Empty), Times.Once());
+        }
+
+        [TestMethod]
+        public async Task CreateRunAsync_WithDependencies_ShouldProvidePackageDependencies()
+        {
+            //Arrange
+            var dependencies = new List<PackageDependency>
+            {
+                new PackageDependency
+                {
+                    Name = "Microsoft.ML",
+                    Version = "1.5.2"
+                }
+            };
+
+            packageDependencyMock.Setup(x => x.IdentifyPackageDependencies()).Returns(dependencies);
+
+            //Act
+            var runId = await sut.CreateRunAsync(Guid.NewGuid());
+
+            //Assert
+            this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), dependencies, string.Empty), Times.Once());
         }
     }
 }

--- a/test/MLOps.NET.Tests/Catalogs/LifeCycleCatalogTests.cs
+++ b/test/MLOps.NET.Tests/Catalogs/LifeCycleCatalogTests.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MLOps.NET.Catalogs;
 using MLOps.NET.Entities.Impl;
+using MLOps.NET.Services.Interfaces;
 using MLOps.NET.Storage;
 using MLOps.NET.Utilities;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MLOps.NET.Tests
@@ -16,6 +18,7 @@ namespace MLOps.NET.Tests
         private Mock<IClock> clockMock;
         private Mock<IExperimentRepository> experimentRepositoryMock;
         private Mock<IRunRepository> runRepositoryMock;
+        private Mock<IPackageDependencyIdentifier> packageDependencyMock;
         private LifeCycleCatalog sut;
 
         [TestInitialize]
@@ -24,7 +27,9 @@ namespace MLOps.NET.Tests
             this.clockMock = new Mock<IClock>();
             this.experimentRepositoryMock = new Mock<IExperimentRepository>();
             this.runRepositoryMock = new Mock<IRunRepository>();
-            this.sut = new LifeCycleCatalog(experimentRepositoryMock.Object, runRepositoryMock.Object, clockMock.Object);
+            this.packageDependencyMock = new Mock<IPackageDependencyIdentifier>();
+
+            this.sut = new LifeCycleCatalog(experimentRepositoryMock.Object, runRepositoryMock.Object, clockMock.Object, packageDependencyMock.Object);
         }
 
         [TestMethod]
@@ -80,7 +85,7 @@ namespace MLOps.NET.Tests
             var runId = await sut.CreateRunAsync(Guid.NewGuid(), gitCommitHash);
 
             //Assert
-            this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), gitCommitHash), Times.Once());
+            this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), new List<PackageDependency>(), gitCommitHash), Times.Once());
         }
 
         [TestMethod]
@@ -91,7 +96,7 @@ namespace MLOps.NET.Tests
             var runId = await sut.CreateRunAsync(Guid.NewGuid());
 
             //Assert
-            this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), string.Empty), Times.Once());
+            this.runRepositoryMock.Verify(x => x.CreateRunAsync(It.IsAny<Guid>(), new List<PackageDependency>(), string.Empty), Times.Once());
         }
     }
 }

--- a/test/MLOps.NET.Tests/Deployments/PackageDependencyIdentifierTests.cs
+++ b/test/MLOps.NET.Tests/Deployments/PackageDependencyIdentifierTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MLOps.NET.Services;
+using System.Linq;
+
+namespace MLOps.NET.Tests.Deployments
+{
+    [TestClass]
+    public class PackageDependencyIdentifierTests
+    {
+        private PackageDependencyIdentifier sut;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.sut = new PackageDependencyIdentifier();
+        }
+
+        [TestMethod]
+        public void IdentifyPackageDependencies_GivenMLNETDependency_ShouldReturnCorrectNameAndVersion()
+        {
+            //Act
+            var packageDependencies = sut.IdentifyPackageDependencies();
+
+            //Assert
+            packageDependencies.All(x => x.Name.StartsWith("Microsoft.ML")).Should().BeTrue();
+            packageDependencies.All(x => x.Version == "1.5.2").Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IdentifyPackageDependencies_GivenFastTreeDependency_ShouldReturnCorrectNameAndVersion()
+        {
+            //Act
+            var packageDependencies = sut.IdentifyPackageDependencies();
+
+            //Assert
+            packageDependencies.Any(x => x.Name == "Microsoft.ML.FastTree" && x.Version == "1.5.2").Should().BeTrue();
+        }
+    }
+}

--- a/test/MLOps.NET.Tests/MLOps.NET.Tests.csproj
+++ b/test/MLOps.NET.Tests/MLOps.NET.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.ML" Version="1.5.2" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="1.5.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />


### PR DESCRIPTION
## Resolves
Fixes #316 

## Description
This PR adds the ability to automatically identify and log any `Microsoft.ML` dependencies during a run. This is important not only for auditability to know what version of ML.NET and what dependencies we used, but also as we can then install all of these dependencies automatically later when building out Docker container.
