### PR TITLE
Added ability to install package dependencies before generating Docker Image

### DIFF
--- a/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
+++ b/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
@@ -127,7 +127,7 @@ namespace MLOps.NET.Catalogs
             using var model = new MemoryStream();
             await modelRepository.DownloadModelAsync(registeredModel.RunId, model);
 
-            await dockerContext.BuildImage(experiment.ExperimentName, registeredModel, model, GetSchema);
+            await dockerContext.BuildImage(experiment, registeredModel, model, GetSchema);
             await dockerContext.PushImage(experiment.ExperimentName, registeredModel);
         }
 

--- a/src/MLOps.NET/Docker/CliExecutor.cs
+++ b/src/MLOps.NET/Docker/CliExecutor.cs
@@ -2,9 +2,11 @@
 using CliWrap.Buffered;
 using MLOps.NET.Docker.Interfaces;
 using MLOps.NET.Docker.Settings;
+using MLOps.NET.Entities.Impl;
 using MLOps.NET.Exceptions;
 using MLOps.NET.Kubernetes.Settings;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +31,28 @@ namespace MLOps.NET.Docker
             {
                 throw new TemplateInstallationException($"Unable to install dotnet new template package ML.NET.Templates with version {dockerSettings.TemplatePackageVersion}", ex);
             }
+        }
+
+        ///<inheritdoc cref="ICliExecutor"/>
+        public async Task AddPackageDependencies(DockerSettings dockerSettings, List<PackageDependency> packageDependencies)
+        {
+            var projectPath = Path.Join(dockerSettings.DirectoryName, dockerSettings.ProjectName);
+
+            foreach (var package in packageDependencies)
+            {
+                try
+                {
+                    Console.WriteLine($"Installing dotnet package dependency {package.Name} with version {package.Version}...");
+
+                    await Cli.Wrap("dotnet")
+                        .WithArguments($"add {projectPath} package {package.Name} --version {package.Version}")
+                        .ExecuteBufferedAsync();
+                }
+                catch (Exception ex)
+                {
+                    throw new AddPackageDependencyException($"Unable to add package dependency {package.Name} with version {package.Version}", ex);
+                }
+            }         
         }
 
         ///<inheritdoc cref="ICliExecutor"/>

--- a/src/MLOps.NET/Docker/Interfaces/ICliExecutor.cs
+++ b/src/MLOps.NET/Docker/Interfaces/ICliExecutor.cs
@@ -1,5 +1,7 @@
 ﻿using MLOps.NET.Docker.Settings;
+using MLOps.NET.Entities.Impl;
 using MLOps.NET.Kubernetes.Settings;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MLOps.NET.Docker.Interfaces
@@ -15,6 +17,12 @@ namespace MLOps.NET.Docker.Interfaces
         /// <param name="dockerSettings"></param>
         /// <returns></returns>
         Task InstallTemplatePackage(DockerSettings dockerSettings);
+
+        /// <summary>
+        /// Adds package dependencies
+        /// </summary>
+        /// <returns></returns>
+        Task AddPackageDependencies(DockerSettings dockerSettings, List<PackageDependency> packageDependencies);
 
         /// <summary>
         /// Uninstall the dotnet new template package for ML.NET.Templates

--- a/src/MLOps.NET/Docker/Interfaces/IDockerContext.cs
+++ b/src/MLOps.NET/Docker/Interfaces/IDockerContext.cs
@@ -13,12 +13,12 @@ namespace MLOps.NET.Docker.Interfaces
         /// <summary>
         /// Builds a docker image
         /// </summary>
-        /// <param name="experimentName"></param>
+        /// <param name="experiment"></param>
         /// <param name="registeredModel"></param>
         /// <param name="model"></param>
         /// <param name="GetSchema"></param>
         /// <returns></returns>
-        Task BuildImage(string experimentName, RegisteredModel registeredModel, Stream model, Func<(string ModelInput, string ModelOutput)> GetSchema);
+        Task BuildImage(Experiment experiment, RegisteredModel registeredModel, Stream model, Func<(string ModelInput, string ModelOutput)> GetSchema);
 
         /// <summary>
         /// Pushes a docker image to a registry

--- a/src/MLOps.NET/Docker/Settings/DockerSettings.cs
+++ b/src/MLOps.NET/Docker/Settings/DockerSettings.cs
@@ -37,5 +37,10 @@
         /// dotnet new template name
         /// </summary>
         public string TemplateName => "mlnet-web-embedded";
+
+        /// <summary>
+        /// Project name
+        /// </summary>
+        public string ProjectName => "ML.NET.Web.Embedded.csproj";
     }
 }

--- a/src/MLOps.NET/Exceptions/AddPackageDependencyException.cs
+++ b/src/MLOps.NET/Exceptions/AddPackageDependencyException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace MLOps.NET.Exceptions
+{
+    /// <summary>
+    /// Custom exception for failure to add package dependency
+    /// </summary>
+    public class AddPackageDependencyException : Exception
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        public AddPackageDependencyException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="ex"></param>
+        public AddPackageDependencyException(string message, Exception ex) : base(message, ex)
+        {
+        }
+    }
+}

--- a/test/MLOps.NET.IntegrationTests/DeploymentCatalogTests.cs
+++ b/test/MLOps.NET.IntegrationTests/DeploymentCatalogTests.cs
@@ -126,5 +126,28 @@ namespace MLOps.NET.IntegrationTests
             File.Exists("image/ML.NET.Web.Embedded.csproj").Should().BeTrue();
             File.Exists("image/model.zip").Should().BeTrue();
         }
+
+        [TestMethod]
+        public async Task BuildAndPushImageAsync_ShouldAddPackageDependencies()
+        {
+            //Arrange
+            await cliExecutor.RemoveDockerImage(tagName);
+
+            var run = await sut.LifeCycle.CreateRunAsync(this.experimentName);
+            var runArtifact = await sut.Model.UploadAsync(run.RunId, @"Data/model.txt");
+            var registeredModel = await sut.Model.RegisterModel(run.ExperimentId, runArtifact.RunArtifactId, "registerby");
+
+            //Act
+            await sut.Deployment.BuildAndPushImageAsync<ModelInput, ModelOutput>(registeredModel);
+
+            //Assert
+            var projectFile = File.ReadAllLines("image/ML.NET.Web.Embedded.csproj");
+
+            var references = projectFile.Where(x => x.StartsWith("PackageReference"));
+
+            references.Any(x => x.Contains(@"Include=""Microsoft.ML"" Version=""1.5.2""")).Should().BeTrue();
+            references.Any(x => x.Contains(@"Include=""Microsoft.ML.CpuMath"" Version=""1.5.2""")).Should().BeTrue();
+            references.Any(x => x.Contains(@"Include=""Microsoft.ML.DataView"" Version=""1.5.2""")).Should().BeTrue();
+        }
     }
 }

--- a/test/MLOps.NET.Tests/Catalogs/DeploymentCatalogTests.cs
+++ b/test/MLOps.NET.Tests/Catalogs/DeploymentCatalogTests.cs
@@ -9,6 +9,7 @@ using MLOps.NET.Storage.Interfaces;
 using MLOps.NET.Tests.Common.Data;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -61,16 +62,28 @@ namespace MLOps.NET.Tests
         {
             //Arrange
             var deploymentTarget = new DeploymentTarget("Test");
-            var registeredModel = new RegisteredModel();
+            var registeredModel = new RegisteredModel
+            {
+                RunId = Guid.NewGuid()
+            };
+
+            var experiment = new Experiment(experimentName: "MyExperiment");
+            experiment.Runs = new List<Run>
+            {
+                new Run(experiment.ExperimentId)
+                {
+                    RunId = registeredModel.RunId
+                }
+            };
 
             this.experimentRepositoryMock.Setup(x => x.GetExperiment(It.IsAny<Guid>()))
-                .Returns(new Experiment(experimentName: "MyExperiment"));
+                .Returns(experiment);
 
             //Act
             await sut.DeployModelToKubernetesAsync<ModelInput, ModelOutput>(deploymentTarget, registeredModel, "registeredBy");
 
             //Arrange
-            this.dockerContextMock.Verify(x => x.BuildImage("MyExperiment", registeredModel, It.IsAny<Stream>(), It.IsAny<Func<(string, string)>>()), Times.Once());
+            this.dockerContextMock.Verify(x => x.BuildImage(experiment, registeredModel, It.IsAny<Stream>(), It.IsAny<Func<(string, string)>>()), Times.Once());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Resolves
Fixes #372 

## Description
This PR adds the ability to install package dependencies in the generated ASP.NET Core project prior to running Docker Build so that all dependencies are accounted for.