### PR TITLE
Add ability to deploy a model to a Kubernetes cluster using the saved schema

### DIFF
--- a/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
+++ b/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
@@ -132,15 +132,15 @@ namespace MLOps.NET.Catalogs
         /// <returns></returns>
         public async Task<Deployment> DeployModelToKubernetesAsync(DeploymentTarget deploymentTarget, RegisteredModel registeredModel, string deployedBy)
         {
+            var run = runRepository.GetRun(registeredModel.RunId);
+
+            if (!run.ModelSchemas.Any())
+            {
+                throw new ModelSchemaNotRegisteredException($"The model schema needs to be registered before deploying a model to a Kubernete cluster. Please use {nameof(LifeCycleCatalog.RegisterModelSchema)} prior to calling this method");
+            }
+
             (string ModelInput, string ModelOutput) GetSchema()
             {
-                var run = runRepository.GetRun(registeredModel.RunId);
-
-                if (!run.ModelSchemas.Any())
-                {
-                    throw new ModelSchemaNotRegisteredException($"The model schema needs to be registered before deploying a model to a Kubernete cluster. Please use {nameof(LifeCycleCatalog.RegisterModelSchema)} prior to calling this method");
-                }
-
                 var modelInput = run.ModelSchemas.First(x => x.Name == Constant.ModelInput);
                 var modelOutput = run.ModelSchemas.First(x => x.Name == Constant.ModelOutput);
 

--- a/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
+++ b/src/MLOps.NET/Catalogs/DeploymentCatalog.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 namespace MLOps.NET.Catalogs

--- a/src/MLOps.NET/Docker/CliExecutor.cs
+++ b/src/MLOps.NET/Docker/CliExecutor.cs
@@ -231,7 +231,7 @@ namespace MLOps.NET.Docker
                     //Skip first line with headers
                     reader.ReadLine();
 
-                    var externalIP = reader.ReadLine().Split("   ")[3];
+                    var externalIP = reader.ReadLine().Split("   ")[3].Trim();
 
                     if (!string.IsNullOrEmpty(externalIP) && !externalIP.ToLower().Contains("pending"))
                     {

--- a/src/MLOps.NET/Docker/DockerContext.cs
+++ b/src/MLOps.NET/Docker/DockerContext.cs
@@ -1,4 +1,5 @@
-﻿using MLOps.NET.Docker.Interfaces;
+﻿using MLOps.NET.Constants;
+using MLOps.NET.Docker.Interfaces;
 using MLOps.NET.Docker.Settings;
 using MLOps.NET.Entities.Impl;
 using System;
@@ -78,8 +79,8 @@ namespace MLOps.NET.Docker
             var directoryPath = $"{dockerSettings.DirectoryName}/Schema";
             fileSystem.Directory.CreateDirectory(directoryPath);
 
-            await fileSystem.File.WriteAllTextAsync($"{directoryPath}/{"ModelInput.cs"}", modelInput);
-            await fileSystem.File.WriteAllTextAsync($"{directoryPath}/{"ModelOutput.cs"}", modelOutput);
+            await fileSystem.File.WriteAllTextAsync($"{directoryPath}/{Constant.ModelInput}.cs", modelInput);
+            await fileSystem.File.WriteAllTextAsync($"{directoryPath}/{Constant.ModelOutput}.cs", modelOutput);
         }
 
         public string ComposeImageName(string experimentName, RegisteredModel registeredModel)

--- a/src/MLOps.NET/Exceptions/ModelSchemaNotRegisteredException.cs
+++ b/src/MLOps.NET/Exceptions/ModelSchemaNotRegisteredException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace MLOps.NET.Exceptions
+{
+    /// <summary>
+    /// Custom exception for lack of registered model schema
+    /// </summary>
+    public class ModelSchemaNotRegisteredException : Exception
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        public ModelSchemaNotRegisteredException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="ex"></param>
+        public ModelSchemaNotRegisteredException(string message, Exception ex) : base(message, ex)
+        {
+        }
+    }
+}

--- a/src/MLOps.NET/MLOpsContext.cs
+++ b/src/MLOps.NET/MLOpsContext.cs
@@ -37,7 +37,7 @@ namespace MLOps.NET
             this.Evaluation = new EvaluationCatalog(metricRepository, confusionMatrixRepository);
             this.Model = new ModelCatalog(modelRepository, runRepository);
             this.Training = new TrainingCatalog(hyperParameterRepository);
-            this.Deployment = new DeploymentCatalog(deploymentRepository, modelRepository, experimentRepository, dockerContext, kubernetesContext, new SchemaGenerator());
+            this.Deployment = new DeploymentCatalog(deploymentRepository, modelRepository, experimentRepository, runRepository, dockerContext, kubernetesContext, new SchemaGenerator());
         }
 
         ///<inheritdoc cref="IMLOpsContext"/>

--- a/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
@@ -160,7 +160,7 @@ namespace MLOps.NET.SQLite.IntegrationTests
             //Act
             await sut.Deployment.DeployModelToKubernetesAsync(deploymentTarget, registeredModel, string.Empty);
 
-            //Excepts exception
+            //Expects exception
         }
 
         private async Task<HttpResponseMessage> CallDeployedApi(Deployment deployment)

--- a/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
@@ -5,6 +5,7 @@ using Microsoft.ML;
 using Microsoft.ML.Transforms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MLOps.NET.Entities.Impl;
+using MLOps.NET.Exceptions;
 using MLOps.NET.Extensions;
 using MLOps.NET.SQLite.IntegrationTests.Constants;
 using MLOps.NET.SQLite.IntegrationTests.Schema;
@@ -78,6 +79,88 @@ namespace MLOps.NET.SQLite.IntegrationTests
             response.IsSuccessStatusCode.Should().BeTrue();
 
             await CleanUpKubernetesResourcesAsync();
+        }
+
+        [TestMethod]
+        public async Task DeployModel_GivenACompleteRunWithRegisteredSchema_ShouldDeployModelToContainer()
+        {
+            //Arrange and Act
+            var mlContext = new MLContext(seed: 2);
+
+            var run = await sut.LifeCycle.CreateRunAsync("titanic");
+            await sut.LifeCycle.RegisterModelSchema<ModelInput, ModelOutput>(run.RunId);
+
+            var data = mlContext.Data.LoadFromTextFile<ModelInput>("Data/titanic.csv", hasHeader: true, separatorChar: ',');
+            var testTrainTest = mlContext.Data.TrainTestSplit(data);
+
+            var dataProcessingPipeline =
+                mlContext.Transforms.ReplaceMissingValues(nameof(ModelInput.Age), replacementMode: MissingValueReplacingEstimator.ReplacementMode.Mean)
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding(nameof(ModelInput.Sex)))
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding(nameof(ModelInput.Pclass)))
+                .Append(mlContext.Transforms.Concatenate("Features", nameof(ModelInput.Pclass), nameof(ModelInput.Sex), nameof(ModelInput.Age)));
+
+            var trainer = dataProcessingPipeline.Append(mlContext.BinaryClassification.Trainers
+                .LbfgsLogisticRegression(nameof(ModelInput.Survived)));
+
+            await sut.Training.LogHyperParametersAsync(run.RunId, trainer);
+
+            var model = trainer.Fit(testTrainTest.TrainSet);
+
+            mlContext.Model.Save(model, testTrainTest.TrainSet.Schema, "model.zip");
+            await sut.Model.UploadAsync(run.RunId, "model.zip");
+
+            var runArtifact = sut.Model.GetRunArtifacts(run.RunId).First();
+
+            var registeredModel = await sut.Model.RegisterModel(run.ExperimentId, runArtifact.RunArtifactId, string.Empty);
+            var deploymentTarget = await sut.Deployment.CreateDeploymentTargetAsync("Test");
+
+            //Act
+            var deployment = await sut.Deployment.DeployModelToKubernetesAsync(deploymentTarget, registeredModel, string.Empty);
+
+            //Assert
+            var response = await CallDeployedApi(deployment);
+            response.IsSuccessStatusCode.Should().BeTrue();
+
+            await CleanUpKubernetesResourcesAsync();
+        }
+
+        [ExpectedException(typeof(ModelSchemaNotRegisteredException))]
+        [TestMethod]
+        public async Task DeployModel_GivenACompleteRunWithoutRegisteredSchema_ShouldThrowException()
+        {
+            //Arrange and Act
+            var mlContext = new MLContext(seed: 2);
+
+            var run = await sut.LifeCycle.CreateRunAsync("titanic");
+
+            var data = mlContext.Data.LoadFromTextFile<ModelInput>("Data/titanic.csv", hasHeader: true, separatorChar: ',');
+            var testTrainTest = mlContext.Data.TrainTestSplit(data);
+
+            var dataProcessingPipeline =
+                mlContext.Transforms.ReplaceMissingValues(nameof(ModelInput.Age), replacementMode: MissingValueReplacingEstimator.ReplacementMode.Mean)
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding(nameof(ModelInput.Sex)))
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding(nameof(ModelInput.Pclass)))
+                .Append(mlContext.Transforms.Concatenate("Features", nameof(ModelInput.Pclass), nameof(ModelInput.Sex), nameof(ModelInput.Age)));
+
+            var trainer = dataProcessingPipeline.Append(mlContext.BinaryClassification.Trainers
+                .LbfgsLogisticRegression(nameof(ModelInput.Survived)));
+
+            await sut.Training.LogHyperParametersAsync(run.RunId, trainer);
+
+            var model = trainer.Fit(testTrainTest.TrainSet);
+
+            mlContext.Model.Save(model, testTrainTest.TrainSet.Schema, "model.zip");
+            await sut.Model.UploadAsync(run.RunId, "model.zip");
+
+            var runArtifact = sut.Model.GetRunArtifacts(run.RunId).First();
+
+            var registeredModel = await sut.Model.RegisterModel(run.ExperimentId, runArtifact.RunArtifactId, string.Empty);
+            var deploymentTarget = await sut.Deployment.CreateDeploymentTargetAsync("Test");
+
+            //Act
+            await sut.Deployment.DeployModelToKubernetesAsync(deploymentTarget, registeredModel, string.Empty);
+
+            //Excepts exception
         }
 
         private async Task<HttpResponseMessage> CallDeployedApi(Deployment deployment)


### PR DESCRIPTION
## Resolves
Fixes #370 

## Description
Added a method to deploy a model to a cluster that uses the registered model schema instead of passing it in at run time.
