### PR TITLE
Updated CI build for sample to only run on changes to the specific folder

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -7,7 +7,7 @@ on:
       - 'samples/**'  
   pull_request:
     branches: [ main ]
-    paths-ignore:
+    paths:
       - 'samples/**'
 jobs:
   Build-samples:


### PR DESCRIPTION
We currently run the samples build for every PR and merge. We rarely change the samples solution so I've updated the samples workflow to only get triggered on updates to anything within this specific folder.
