### PR TITLE
Add option for choosing sqlitedb file path

### DIFF
--- a/src/MLOps.NET.SQLite/MLOpsBuilderExtensions.cs
+++ b/src/MLOps.NET.SQLite/MLOpsBuilderExtensions.cs
@@ -12,11 +12,14 @@ namespace MLOps.NET.SQLite
         /// Enables the usage of SQLite
         /// </summary>
         /// <param name="builder">MLOpsBuilder for using SQLite</param>
+        /// <param name="dbFileLocation">Path to SQLite database file</param>
         /// <returns>Provided MLOpsBuilder for chaining</returns>
-        public static MLOpsBuilder UseSQLite(this MLOpsBuilder builder)
+        public static MLOpsBuilder UseSQLite(this MLOpsBuilder builder, string dbFileLocation = null)
         {
+            var location = dbFileLocation == null ? "local.db" : dbFileLocation;
+
             var options = new DbContextOptionsBuilder()
-                .UseSqlite("Data Source=local.db")
+                .UseSqlite($"Data Source={location}")
                 .Options;
 
             var contextFactory = new DbContextFactory(() => new MLOpsSQLiteDbContext(options));

--- a/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
+++ b/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
@@ -61,19 +61,19 @@ namespace MLOps.NET.SQLite.Tests
         public void UseSqlLite_ConfiguresAlternativeSQLiteDbPath()
         {
             var tempPath = Path.GetTempPath();
-            var tmpDbName = Guid.NewGuid().ToString();
-            var tmpDbPath = Path.Combine(tempPath, $"{tmpDbName}.db");
+            var tempDbName = Guid.NewGuid().ToString();
+            var tempDbPath = Path.Combine(tempPath, $"{tempDbName}.db");
 
             //Act
             IMLOpsContext unitUnderTest = new MLOpsBuilder()
-                .UseSQLite(tmpDbPath)
+                .UseSQLite(tempDbPath)
                 .UseModelRepository(new Mock<IModelRepository>().Object)
                 .Build();
 
             unitUnderTest.Should().BeOfType<MLOpsContext>("Because the default IMLLifeCycleManager is MLLifeCycleManager");
 
             //Assert
-            File.Exists(tmpDbPath).Should().BeTrue();
+            File.Exists(tempDbPath).Should().BeTrue();
         }
     }
 }

--- a/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
+++ b/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
@@ -56,24 +56,5 @@ namespace MLOps.NET.SQLite.Tests
             //Assert
             unitUnderTest.LifeCycle.Should().NotBeNull();
         }
-
-        [TestMethod]
-        public void UseSqlLite_ConfiguresAlternativeSQLiteDbPath()
-        {
-            var tempPath = Path.GetTempPath();
-            var tempDbName = Guid.NewGuid().ToString();
-            var tempDbPath = Path.Combine(tempPath, $"{tempDbName}.db");
-
-            //Act
-            IMLOpsContext unitUnderTest = new MLOpsBuilder()
-                .UseSQLite(tempDbPath)
-                .UseModelRepository(new Mock<IModelRepository>().Object)
-                .Build();
-
-            unitUnderTest.Should().BeOfType<MLOpsContext>("Because the default IMLLifeCycleManager is MLLifeCycleManager");
-
-            //Assert
-            File.Exists(tempDbPath).Should().BeTrue();
-        }
     }
 }

--- a/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
+++ b/test/MLOps.NET.SQLite.Tests/MLOpsBuilderExtensionTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.IO;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MLOps.NET.Storage;
 using Moq;
@@ -53,6 +55,25 @@ namespace MLOps.NET.SQLite.Tests
 
             //Assert
             unitUnderTest.LifeCycle.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void UseSqlLite_ConfiguresAlternativeSQLiteDbPath()
+        {
+            var tempPath = Path.GetTempPath();
+            var tmpDbName = Guid.NewGuid().ToString();
+            var tmpDbPath = Path.Combine(tempPath, $"{tmpDbName}.db");
+
+            //Act
+            IMLOpsContext unitUnderTest = new MLOpsBuilder()
+                .UseSQLite(tmpDbPath)
+                .UseModelRepository(new Mock<IModelRepository>().Object)
+                .Build();
+
+            unitUnderTest.Should().BeOfType<MLOpsContext>("Because the default IMLLifeCycleManager is MLLifeCycleManager");
+
+            //Assert
+            File.Exists(tmpDbPath).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
## Resolves
https://github.com/aslotte/MLOps.NET/issues/474

## Description
- Adds a pass through option for setting the SQLite `Data Source`
- Adds minimal test to show, that db file gets initialized
