### PR TITLE
Update ML.NET.Templates dependency to 0.4.0-beta

### DIFF
--- a/src/MLOps.NET/Docker/Settings/DockerSettings.cs
+++ b/src/MLOps.NET/Docker/Settings/DockerSettings.cs
@@ -34,7 +34,7 @@ namespace MLOps.NET.Docker.Settings
         /// <summary>
         /// Verision of ML.NET.Templates
         /// </summary>
-        public static string TemplatePackageVersion => "0.3.0-beta";
+        public static string TemplatePackageVersion => "0.4.0-beta";
         /// <summary>
         /// dotnet new template name
         /// </summary>


### PR DESCRIPTION
## Description
v0.4.0-beta runs on .NET 5, defaults to v1.5.4 of ML.NET and supports Swagger.
