### PR TITLE
Improve scaling of Kubernetes end-to-end integration test

### DIFF
--- a/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
@@ -46,7 +46,7 @@ namespace MLOps.NET.SQLite.IntegrationTests
             //Arrange and Act
             var mlContext = new MLContext(seed: 2);
 
-            var seed = new Random().Next(0, 50);
+            var seed = new Random().Next(0, 1000);
             var experimentName = $"titanic-{seed}";
 
             var run = await sut.LifeCycle.CreateRunAsync(experimentName);

--- a/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
+++ b/test/MLOps.NET.SQLite.IntegrationTests/KubernetesEndToEndTests.cs
@@ -11,6 +11,7 @@ using MLOps.NET.SQLite.IntegrationTests.Constants;
 using MLOps.NET.SQLite.IntegrationTests.Schema;
 using MLOps.NET.Tests.Common.Configuration;
 using Newtonsoft.Json;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -45,7 +46,10 @@ namespace MLOps.NET.SQLite.IntegrationTests
             //Arrange and Act
             var mlContext = new MLContext(seed: 2);
 
-            var run = await sut.LifeCycle.CreateRunAsync("titanic");
+            var seed = new Random().Next(0, 50);
+            var experimentName = $"titanic-{seed}";
+
+            var run = await sut.LifeCycle.CreateRunAsync(experimentName);
 
             var data = mlContext.Data.LoadFromTextFile<ModelInput>("Data/titanic.csv", hasHeader: true, separatorChar: ',');
             var testTrainTest = mlContext.Data.TrainTestSplit(data);


### PR DESCRIPTION
## Resolves
Fixes #397 

## Description
The experiment name is part of the Kubernetes namespace being generated. We currently use the same name for each test run so if there are multiple test runs in parallel (e.g. when Dependabot bumps multiple dependencies at the same time) resources may be generated in a namespace that is being terminated.

This PR ensures that each test is run in a random namespace