### PR TITLE
Ensure that a new release always pushes packages to nuget.org

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -3,7 +3,8 @@ on:
     types: [published]
 
 name: Publish to nuget.org
-          
+
+# Note that the VERSION_STATIC is set to 0.0.0.0. This is so that the action uses the version of Nerdversioning as well as always pushes a new package to nuget.org         
 jobs:
   build:
     name: Push packages
@@ -16,50 +17,46 @@ jobs:
         uses: actions/setup-dotnet@v1        
         with:
           dotnet-version: 5.0.x        
-      - name: Install dependencies
-        run: dotnet restore MLOps.NET.sln
-      - name: Build
-        run: dotnet build MLOps.NET.sln --configuration Release --no-restore
       - name: Publish MLOps.NET
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET/MLOps.NET.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}} 
-          VERSION_STATIC: 1.0.0    
+          VERSION_STATIC: 0.0.0   
           TAG_COMMIT: false    
       - name: Publish MLOps.NET.AWS             
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET.AWS/MLOps.NET.AWS.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}  
-          VERSION_STATIC: 1.0.0   
+          VERSION_STATIC: 0.0.0   
           TAG_COMMIT: false       
       - name: Publish MLOps.NET.Azure          
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET.Azure/MLOps.NET.Azure.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}  
-          VERSION_STATIC: 1.0.0   
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          VERSION_STATIC: 0.0.0      
           TAG_COMMIT: false  
       - name: Publish MLOps.NET.SQLite          
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET.SQLite/MLOps.NET.SQLite.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}} 
-          VERSION_STATIC: 1.0.0    
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}  
+          VERSION_STATIC: 0.0.0   
           TAG_COMMIT: false        
       - name: Publish MLOps.NET.SQLServer          
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET.SQLServer/MLOps.NET.SQLServer.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}     
-          VERSION_STATIC: 1.0.0
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}} 
+          VERSION_STATIC: 0.0.0       
           TAG_COMMIT: false    
       - name: Publish MLOps.NET.CLI          
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/MLOps.NET.CLI/MLOps.NET.CLI.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}     
-          VERSION_STATIC: 1.0.0
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}    
+          VERSION_STATIC: 0.0.0    
           TAG_COMMIT: false           
                                                                          


### PR DESCRIPTION
## Resolves
Partially resolves #488 

## Description
We have previously seen that a new release doesn't push a new package to nuget.org when release-nuget.yml is run. 
This is because the action we use use, uses VERSION_STATIC to check for if the package already exists, although we set the version using Nerdversioning which resolves a version in a later stage. Setting it to 0.0.0.0 ensures that it always pushes a new package. If a duplicate exists, the nuget.org API will tell us instead.
