### PR TITLE
Fix version conflicts caused by PR#713

### DIFF
--- a/src/MLOps.NET.SQLite/MLOps.NET.SQLite.csproj
+++ b/src/MLOps.NET.SQLite/MLOps.NET.SQLite.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="5.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.7" />     
   </ItemGroup>
 

--- a/test/MLOps.NET.SQLite.IntegrationTests/MLOps.NET.SQLite.IntegrationTests.csproj
+++ b/test/MLOps.NET.SQLite.IntegrationTests/MLOps.NET.SQLite.IntegrationTests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />    
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.9" />    
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore.Sqlite from 5.0.6 to 5.0.9. [(PR#713)](https://github.com/aslotte/MLOps.NET/pull/713).
Hope this fix can help you.

Best regards,
sucrose